### PR TITLE
add function to get RenderTexture inner texture field.

### DIFF
--- a/src/image.h
+++ b/src/image.h
@@ -129,6 +129,14 @@ static Janet cfun_GetScreenData(int32_t argc, Janet *argv) {
     return janet_wrap_abstract(image);
 }
 
+static Janet cfun_GetRenderTextureTexture2d(int32_t argc, Janet *argv) {
+  janet_fixarity(argc, 1);
+  RenderTexture renderTexture = *jaylib_getrendertexture(argv, 0);
+  Texture2D *texture = janet_abstract(&AT_Texture2D, sizeof(Texture2D));
+  *texture = renderTexture.texture;
+  return janet_wrap_abstract(texture);
+}
+
 static Janet cfun_ImageCopy(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
     Image image = *jaylib_getimage(argv, 0);
@@ -662,6 +670,7 @@ static const JanetReg image_cfuns[] = {
     {"get-image-dimensions", cfun_GetImageDimensions, NULL},
     {"get-texture-data", cfun_GetTextureData, NULL},
     {"get-screen-data", cfun_GetScreenData, NULL},
+    {"get-rendertexture-texture", cfun_GetRenderTextureTexture2d, NULL},
     {"image-copy", cfun_ImageCopy, NULL},
     {"image-from-image", cfun_ImageFromImage, NULL},
     {"image-to-pot", cfun_ImageToPOT, NULL},

--- a/src/image.h
+++ b/src/image.h
@@ -670,7 +670,7 @@ static const JanetReg image_cfuns[] = {
     {"get-image-dimensions", cfun_GetImageDimensions, NULL},
     {"get-texture-data", cfun_GetTextureData, NULL},
     {"get-screen-data", cfun_GetScreenData, NULL},
-    {"get-rendertexture-texture", cfun_GetRenderTextureTexture2d, NULL},
+    {"get-render-texture-texture2d", cfun_GetRenderTextureTexture2d, NULL},
     {"image-copy", cfun_ImageCopy, NULL},
     {"image-from-image", cfun_ImageFromImage, NULL},
     {"image-to-pot", cfun_ImageToPOT, NULL},


### PR DESCRIPTION
this is useful to render at a different resolution then the window.

```clojure
(use ../build/jaylib)

(set-trace-log-callback nil)

(init-window 800 600 "Test Game")
(set-target-fps 60)

(def target (load-render-texture 400 300))

(while (not (window-should-close))
  (begin-texture-mode target)
    (draw-circle 200 150 60 :black)
  (end-texture-mode)

  (begin-drawing)
    (clear-background :white)
    (draw-texture-ex (get-rendertexture-texture target) [0 0] 0 2 :white)
  (end-drawing))
(close-window)
```

thank you for this great library! I'm open to any suggestions :) 