### PR TITLE
jaylib_wrap_vec2: don't truncate floats to integers

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -382,8 +382,8 @@ static int jaylib_getpixelformat(const Janet *argv, int32_t n) {
 
 static Janet jaylib_wrap_vec2(Vector2 x) {
     Janet *tup = janet_tuple_begin(2);
-    tup[0] = janet_wrap_integer(x.x);
-    tup[1] = janet_wrap_integer(x.y);
+    tup[0] = janet_wrap_number(x.x);
+    tup[1] = janet_wrap_number(x.y);
     return janet_wrap_tuple(janet_tuple_end(tup));
 }
 


### PR DESCRIPTION
This might technically be a breaking change, but I think it's a pretty important bugfix.

Raylib's `Vector2` contains two floats, but Jaylib truncates those to integers when it returns them (note that they are parsed as floats correctly).

This can lead to some pretty confusing behavior -- not necessarily with any of the currently implemented functions that return vectors, but this prohibits wrapping some other Raylib functions that do not always return integers.