### PR TITLE
fix macOS build

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -6,7 +6,7 @@
 
 (def cflags
   (case o
-    :macos '["-Iraylib/src" "-ObjC"]
+    :macos '["-Iraylib/src" "-ObjC" "-Iraylib/src/external/glfw/include"]
     :windows ["-Iraylib/src" "-Iraylib/src/external/glfw/include" ]
     #default
     '["-Iraylib/src"]))


### PR DESCRIPTION
This is already in the include path for the windows build, but it's necessary on macOS as well.

I didn't test the build on Linux to see if it matters there too, so I left it alone.

Without this change, `jpm build` fails with:

```
raylib/src/core.c:193:14: fatal error: 'GLFW/glfw3.h' file not found
    #include "GLFW/glfw3.h"         // GLFW3 library: Windows, OpenGL contex...
```