### PR TITLE
Add cursor-on-screen? binding

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -34,6 +34,7 @@
 [x] bool IsCursorHidden(void)
 [x] void EnableCursor(void)
 [x] void DisableCursor(void)
+[x] bool IsCursorOnScreen(void)
 
 // Drawing-related functions
 [x] void ClearBackground(Color color)

--- a/src/core.h
+++ b/src/core.h
@@ -273,6 +273,12 @@ static Janet cfun_DisableCursor(int32_t argc, Janet *argv) {
     return janet_wrap_nil();
 }
 
+static Janet cfun_IsCursorOnScreen(int32_t argc, Janet *argv) {
+	(void) argv;
+	janet_fixarity(argc, 0);
+	return janet_wrap_boolean(IsCursorOnScreen());
+}
+
 static Janet cfun_ClearBackground(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
     Color color = jaylib_getcolor(argv, 0);
@@ -893,6 +899,7 @@ static JanetReg core_cfuns[] = {
     {"cursor-hidden?", cfun_IsCursorHidden, NULL},
     {"enable-cursor", cfun_EnableCursor, NULL},
     {"disable-cursor", cfun_DisableCursor, NULL},
+    {"cursor-on-screen?", cfun_IsCursorOnScreen, NULL},
     {"clear-background", cfun_ClearBackground, NULL},
     {"begin-drawing", cfun_BeginDrawing, NULL},
     {"end-drawing", cfun_EndDrawing, NULL},


### PR DESCRIPTION
Adds a binding to the Raylib function `bool IsCursorOnScreen(void)`[^1], represented here in Jaylib as `cursor-on-screen?`.

[^1]: Seen in the Core/cusor-related functions section of the cheatsheet: https://www.raylib.com/cheatsheet/cheatsheet.html