### PR TITLE
Fix a bug in the example program

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for an overview of which API functions have been ported.
 
   (clear-background [0 0 0])
   (let [[x y] (get-mouse-position)]
-    (draw-circle-gradient x y 31.4 :lime :red)
+    (draw-circle-gradient (math/floor x) (math/floor y) 31.4 :lime :red)
     (draw-poly [500 200] 5 40 0 :magenta)
     (draw-line-bezier
       [(- x 100) y]


### PR DESCRIPTION
draw-circle-gradient's 'x' and 'y' arguments must be integers, but
get-mouse-position returns two floats.

Maybe it used to work with previous versions of Raylib, but I don't
think it's the case with 3.7.0.

Edit: Oh, heh, I'm sure it's related to this: https://github.com/janet-lang/jaylib/pull/24