### PR TITLE
jaylib_getcolor hex abgr -> rgba

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -280,10 +280,10 @@ static Color jaylib_getcolor(const Janet *argv, int32_t n) {
     } else if (janet_checktype(x, JANET_NUMBER)) {
         int64_t value = janet_getinteger64(argv, n);
         return (Color) {
-            ((value >> 0)  & 0xFF),
+            ((value >> 24)  & 0xFF),
+            ((value >> 16)  & 0xFF),
             ((value >> 8)  & 0xFF),
-            ((value >> 16) & 0xFF),
-            ((value >> 24) & 0xFF)
+            ((value >> 0)  & 0xFF)
         };
     } else {
         const uint8_t *nameu = janet_getkeyword(argv, n);


### PR DESCRIPTION
After doing some testing, it seems that jaylib_getcolor has the format of abgr.

bakpakin said

>I don't think that color order is abrg if I recall. I think I intentionally chose whatever raylib used, or simply picked something that made sense with hexcodes. If not, I don't recall why I set it up the way I did.

When trying with raylib, I got:
```
printf("%x\n", ColorToInt((Color){128, 64, 0, 255}));
// prints:
804000ff
```

Which implies it uses rgba. When looking at the Color struct, the order is rgba (https://github.com/raysan5/raylib/blob/master/examples/others/rlgl_standalone.c#L81-L87), and when I tried rendering text with color `(Color){255, 0, 0, 255}` it was red.

In addition to following raylib, using rgba makes it easier to copy hex colors from other tools like image editors.

Therefore I suggest that we change jaylib's jaylib_getcolor to rgba.