### PR TITLE
Partial update to Raylib 4.0.0

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -29,13 +29,13 @@
   :source ["src/main.c"
 
            # raylib sources
-           "raylib/src/core.c"
-           "raylib/src/models.c"
+           "raylib/src/rcore.c"
+           "raylib/src/rmodels.c"
            "raylib/src/raudio.c"
            "raylib/src/rglfw.c"
-           "raylib/src/shapes.c"
-           "raylib/src/text.c"
-           "raylib/src/textures.c"
+           "raylib/src/rshapes.c"
+           "raylib/src/rtext.c"
+           "raylib/src/rtextures.c"
            "raylib/src/utils.c"]
 
   :headers ["src/core.h"

--- a/src/3d.h
+++ b/src/3d.h
@@ -166,6 +166,5 @@ static JanetReg threed_cfuns[] = {
     {"draw-cylinder-wires", cfun_DrawCylinderWires, NULL},
     {"draw-plane", cfun_DrawPlane, NULL},
     {"draw-ray", cfun_DrawRay, NULL},
-    {"draw-grid", cfun_DrawGrid, NULL},
     {NULL, NULL, NULL}
 };

--- a/src/audio.h
+++ b/src/audio.h
@@ -199,10 +199,10 @@ static Janet cfun_ResumeMusicStream(int32_t argc, Janet *argv) {
     return janet_wrap_nil();
 }
 
-static Janet cfun_IsMusicPlaying(int32_t argc, Janet *argv) {
+static Janet cfun_IsMusicStreamPlaying(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
     Music music = *jaylib_getmusic(argv, 0);
-    return janet_wrap_boolean(IsMusicPlaying(music));
+    return janet_wrap_boolean(IsMusicStreamPlaying(music));
 }
 
 static Janet cfun_SetMusicVolume(int32_t argc, Janet *argv) {
@@ -233,13 +233,13 @@ static Janet cfun_GetMusicTimePlayed(int32_t argc, Janet *argv) {
     return janet_wrap_number((double) GetMusicTimePlayed(music));
 }
 
-static Janet cfun_InitAudioStream(int32_t argc, Janet *argv) {
+static Janet cfun_LoadAudioStream(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 3);
     unsigned int sampleRate = (unsigned) janet_getinteger(argv, 0);
     unsigned int sampleSize = (unsigned) janet_getinteger(argv, 1);
     unsigned int channels = (unsigned) janet_getinteger(argv, 2);
     AudioStream *audioStream = janet_abstract(&AT_AudioStream, sizeof(AudioStream));
-    *audioStream = InitAudioStream(sampleRate, sampleSize, channels);
+    *audioStream = LoadAudioStream(sampleRate, sampleSize, channels);
     return janet_wrap_abstract(audioStream);
 }
 
@@ -252,10 +252,10 @@ static Janet cfun_UpdateAudioStream(int32_t argc, Janet *argv) {
     return janet_wrap_nil();
 }
 
-static Janet cfun_CloseAudioStream(int32_t argc, Janet *argv) {
+static Janet cfun_UnloadAudioStream(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
     AudioStream stream = *jaylib_getaudiostream(argv, 0);
-    CloseAudioStream(stream);
+    UnloadAudioStream(stream);
     return janet_wrap_nil();
 }
 
@@ -353,14 +353,14 @@ static JanetReg audio_cfuns[] = {
     {"pause-music-stream", cfun_PauseMusicStream, NULL},
     {"stop-music-stream", cfun_StopMusicStream, NULL},
     {"resume-music-stream", cfun_ResumeMusicStream, NULL},
-    {"music-playing?", cfun_IsMusicPlaying, NULL},
+    {"music-stream-playing?", cfun_IsMusicStreamPlaying, NULL},
     {"set-music-volume", cfun_SetMusicVolume, NULL},
     {"set-music-pitch", cfun_SetMusicPitch, NULL},
     {"get-music-time-length", cfun_GetMusicTimeLength, NULL},
     {"get-music-time-played", cfun_GetMusicTimePlayed, NULL},
-    {"init-audio-stream", cfun_InitAudioStream, NULL},
+    {"load-audio-stream", cfun_LoadAudioStream, NULL},
     {"update-audio-stream", cfun_UpdateAudioStream, NULL},
-    {"close-audio-stream", cfun_CloseAudioStream, NULL},
+    {"unload-audio-stream", cfun_UnloadAudioStream, NULL},
     {"audio-stream-processed?", cfun_IsAudioStreamProcessed, NULL},
     {"audio-stream-playing?", cfun_IsAudioStreamPlaying, NULL},
     {"play-audio-stream", cfun_PlayAudioStream, NULL},

--- a/src/core.h
+++ b/src/core.h
@@ -522,13 +522,6 @@ static Janet cfun_IsGamepadAvailable(int32_t argc, Janet *argv) {
     return janet_wrap_boolean(IsGamepadAvailable(gamepad));
 }
 
-static Janet cfun_IsGamepadName(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 2);
-    int gamepad = janet_getinteger(argv, 0);
-    const char *name = janet_getcstring(argv, 1);
-    return janet_wrap_boolean(IsGamepadName(gamepad, name));
-}
-
 static Janet cfun_GetGamepadName(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
     int gamepad = janet_getinteger(argv, 0);
@@ -921,7 +914,6 @@ static JanetReg core_cfuns[] = {
     {"get-key-pressed", cfun_GetKeyPressed, NULL},
     {"set-exit-key", cfun_SetExitKey, NULL},
     {"gamepad-available?", cfun_IsGamepadAvailable, NULL},
-    {"gamepad-name?", cfun_IsGamepadName, NULL},
     {"gamepad-button-down?", cfun_IsGamepadButtonDown, NULL},
     {"gamepad-button-up?", cfun_IsGamepadButtonUp, NULL},
     {"gamepad-button-pressed?", cfun_IsGamepadButtonPressed, NULL},

--- a/src/gestures.h
+++ b/src/gestures.h
@@ -69,10 +69,10 @@ static Janet cfun_GetGestureDetected(int32_t argc, Janet *argv) {
     }
 }
 
-static Janet cfun_GetTouchPointsCount(int32_t argc, Janet *argv) {
+static Janet cfun_GetTouchPointCount(int32_t argc, Janet *argv) {
     (void) argv;
     janet_fixarity(argc, 0);
-    return janet_wrap_integer(GetTouchPointsCount());
+    return janet_wrap_integer(GetTouchPointCount());
 }
 
 static Janet cfun_GetGestureHoldDuration(int32_t argc, Janet *argv) {
@@ -109,7 +109,7 @@ static JanetReg gesture_cfuns[] = {
     {"set-gestures-enabled", cfun_SetGesturesEnabled, NULL},
     {"gesture-detected?", cfun_IsGestureDetected, NULL},
     {"get-gesture-detected", cfun_GetGestureDetected, NULL},
-    {"get-touch-points-count", cfun_GetTouchPointsCount, NULL},
+    {"get-touch-point-count", cfun_GetTouchPointCount, NULL},
     {"get-gesture-hold-duration", cfun_GetGestureHoldDuration, NULL},
     {"get-gesture-drag-vector", cfun_GetGestureDragVector, NULL},
     {"get-gesture-drag-angle", cfun_GetGestureDragAngle, NULL},

--- a/src/image.h
+++ b/src/image.h
@@ -100,19 +100,19 @@ static Janet cfun_UnloadRenderTexture(int32_t argc, Janet *argv) {
     return janet_wrap_nil();
 }
 
-static Janet cfun_GetTextureData(int32_t argc, Janet *argv) {
+static Janet cfun_LoadImageFromTexture(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
     Texture2D texture = *jaylib_gettexture2d(argv, 0);
     Image *image = janet_abstract(&AT_Image, sizeof(Image));
-    *image = GetTextureData(texture);
+    *image = LoadImageFromTexture(texture);
     return janet_wrap_abstract(image);
 }
 
-static Janet cfun_GetScreenData(int32_t argc, Janet *argv) {
+static Janet cfun_LoadImageFromScreen(int32_t argc, Janet *argv) {
     (void) argv;
     janet_fixarity(argc, 0);
     Image *image = janet_abstract(&AT_Image, sizeof(Image));
-    *image = GetScreenData();
+    *image = LoadImageFromScreen();
     return janet_wrap_abstract(image);
 }
 
@@ -546,18 +546,6 @@ static Janet cfun_GenImageWhiteNoise(int32_t argc, Janet *argv) {
     return janet_wrap_abstract(image);
 }
 
-static Janet cfun_GenImagePerlinNoise(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 5);
-    int width = janet_getinteger(argv, 0);
-    int height = janet_getinteger(argv, 1);
-    int offsetX = janet_getinteger(argv, 2);
-    int offsetY = janet_getinteger(argv, 3);
-    float factor = (float) janet_getnumber(argv, 4);
-    Image *image = janet_abstract(&AT_Image, sizeof(Image));
-    *image = GenImagePerlinNoise(width, height, offsetX, offsetY, factor);
-    return janet_wrap_abstract(image);
-}
-
 static Janet cfun_GenImageCellular(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 3);
     int width = janet_getinteger(argv, 0);
@@ -655,8 +643,8 @@ static const JanetReg image_cfuns[] = {
     {"unload-texture", cfun_UnloadTexture, NULL},
     {"unload-render-texture", cfun_UnloadRenderTexture, NULL},
     {"get-image-dimensions", cfun_GetImageDimensions, NULL},
-    {"get-texture-data", cfun_GetTextureData, NULL},
-    {"get-screen-data", cfun_GetScreenData, NULL},
+    {"load-image-from-texture", cfun_LoadImageFromTexture, NULL},
+    {"load-image-from-screen", cfun_LoadImageFromScreen, NULL},
     {"get-render-texture-texture2d", cfun_GetRenderTextureTexture2d, NULL},
     {"image-copy", cfun_ImageCopy, NULL},
     {"image-from-image", cfun_ImageFromImage, NULL},
@@ -703,7 +691,6 @@ static const JanetReg image_cfuns[] = {
     {"gen-image-gradient-radial", cfun_GenImageGradientRadial, NULL},
     {"gen-image-checked", cfun_GenImageChecked, NULL},
     {"gen-image-white-noise", cfun_GenImageWhiteNoise, NULL},
-    {"gen-image-perlin-noise", cfun_GenImagePerlinNoise, NULL},
     {"gen-image-cellular", cfun_GenImageCellular, NULL},
     {"gen-texture-mipmaps", cfun_GenTextureMipmaps, NULL},
     {"set-texture-filter", cfun_SetTextureFilter, NULL},

--- a/src/text.h
+++ b/src/text.h
@@ -84,37 +84,6 @@ static Janet cfun_DrawTextEx(int32_t argc, Janet *argv) {
     return janet_wrap_nil();
 }
 
-static Janet cfun_DrawTextRec(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 7);
-    Font font = *jaylib_getfont(argv, 0);
-    const char *text = jaylib_getcstring(argv, 1);
-    Rectangle rect = jaylib_getrect(argv, 2);
-    float fontSize = (float) janet_getnumber(argv, 3);
-    float spacing = (float) janet_getnumber(argv, 4);
-    bool wordWrap = janet_truthy(argv[5]);
-    Color color = jaylib_getcolor(argv, 6);
-    DrawTextRec(font, text, rect, fontSize, spacing, wordWrap, color);
-    return janet_wrap_nil();
-}
-
-static Janet cfun_DrawTextRecEx(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 11);
-    Font font = *jaylib_getfont(argv, 0);
-    const char *text = jaylib_getcstring(argv, 1);
-    Rectangle rect = jaylib_getrect(argv, 2);
-    float fontSize = (float) janet_getnumber(argv, 3);
-    float spacing = (float) janet_getnumber(argv, 4);
-    bool wordWrap = janet_truthy(argv[5]);
-    Color color = jaylib_getcolor(argv, 6);
-    int selectStart = janet_getinteger(argv, 7);
-    int selectLength = janet_getinteger(argv, 8);
-    Color selectText = jaylib_getcolor(argv, 9);
-    Color selectBack = jaylib_getcolor(argv, 10);
-    DrawTextRecEx(font, text, rect, fontSize, spacing, wordWrap, color,
-            selectStart, selectLength, selectText, selectBack);
-    return janet_wrap_nil();
-}
-
 static Janet cfun_MeasureText(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 2);
     const char *text = jaylib_getcstring(argv, 0);
@@ -154,8 +123,6 @@ static JanetReg text_cfuns[] = {
     {"draw-fps", cfun_DrawFPS, NULL},
     {"draw-text", cfun_DrawText, NULL},
     {"draw-text-ex", cfun_DrawTextEx, NULL},
-    {"draw-text-rec", cfun_DrawTextRec, NULL},
-    {"draw-text-rec-ex", cfun_DrawTextRecEx, NULL},
     {"measure-text", cfun_MeasureText, NULL},
     {"measure-text-ex", cfun_MeasureTextEx, NULL},
     {"get-glyph-index", cfun_GetGlyphIndex, NULL},

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -9,11 +9,6 @@
 (set-target-fps 60)
 (hide-cursor)
 
-(def lorem-ipsum
-  ```
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  ```)
-
 (var rot 0)
 
 (while (not (window-should-close))
@@ -41,8 +36,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
   (draw-fps 10 10)
   (draw-text "Hello, world!" 100 100 (math/floor (+ 20 (* 5 (math/random)))) :blue)
-
-  (draw-text-rec (get-font-default) lorem-ipsum [100 100 1000 600] 20 2 true :red)
 
   (end-drawing))
 


### PR DESCRIPTION
This PR mostly contains changes to update to Raylib 4.0.0.

It isn't a complete update but rather attends to:

* filename changes,
* function name changes, and
* function removals

for what already exists in jaylib.

One existing jaylib test was changed to remove the use of `draw-text-rec` as the corresponding Raylib function `DrawTextRec` was removed in Raylib 4.0.0.

On a side note [Raylib's CHANGELOG](https://github.com/raysan5/raylib/blob/d4382f4a52e7631bf02ff8073ed24b282596ce0a/CHANGELOG) file was consulted to verify that most of the changes were expected.

There is also a change for removing a duplicate `draw-grid` -- this is unrelated to updating to Raylib 4.
