### PR TITLE
Add docstrings to jaylib functions

### DIFF
--- a/src/3d.h
+++ b/src/3d.h
@@ -151,20 +151,65 @@ static Janet cfun_DrawRay(int32_t argc, Janet *argv) {
 }
 
 static JanetReg threed_cfuns[] = {
-    {"draw-line-3d", cfun_DrawLine3D, NULL},
-    {"draw-circle-3d", cfun_DrawCircle3D, NULL},
-    {"draw-cube", cfun_DrawCube, NULL},
-    {"draw-cube-v", cfun_DrawCubeV, NULL},
-    {"draw-cube-wires", cfun_DrawCubeWires, NULL},
-    {"draw-cube-wires-v", cfun_DrawCubeWiresV, NULL},
-    {"draw-cube-texture", cfun_DrawCubeTexture, NULL},
-    {"draw-grid", cfun_DrawGrid, NULL},
-    {"draw-sphere", cfun_DrawSphere, NULL},
-    {"draw-sphere-ex", cfun_DrawSphereEx, NULL},
-    {"draw-sphere-wires", cfun_DrawSphereWires, NULL},
-    {"draw-cylinder", cfun_DrawCylinder, NULL},
-    {"draw-cylinder-wires", cfun_DrawCylinderWires, NULL},
-    {"draw-plane", cfun_DrawPlane, NULL},
-    {"draw-ray", cfun_DrawRay, NULL},
+    {"draw-line-3d", cfun_DrawLine3D, 
+        "(draw-line-3d [start-x start-y start-z] [end-x end-y end-z] color)\n\n"
+        "Draw a line in 3D world space"
+    },
+    {"draw-circle-3d", cfun_DrawCircle3D, 
+        "(draw-circle-3d [center-x center-y center-z] radius [rot-x rot-y rot-z] rotation-angle color)\n\n"
+        "Draw a circle in 3D world space"
+    },
+    {"draw-cube", cfun_DrawCube, 
+        "(draw-cube [center-x center-y center-z] width height length color)\n\n"
+        "Draw cube"
+    },
+    {"draw-cube-v", cfun_DrawCubeV, 
+        "(draw-cube-v [center-x center-y center-z] [width height length] color)\n\n"
+        "Draw cube (Vector version)"
+    },
+    {"draw-cube-wires", cfun_DrawCubeWires, 
+        "(draw-cube-wires [center-x center-y center-z] width height length color)\n\n"
+        "Draw cube wires"
+    },
+    {"draw-cube-wires-v", cfun_DrawCubeWiresV, 
+        "(draw-cube-wires-v [center-x center-y center-z] [width height length] color)\n\n"
+        "Draw cube wires (Vector version)"
+    },
+    {"draw-cube-texture", cfun_DrawCubeTexture, 
+        "(draw-cube-texture texture [center-x center-y center-z] width height length color)\n\n"
+        "Draw cube textured"
+    },
+    {"draw-grid", cfun_DrawGrid, 
+        "(draw-grid slices spacing)\n\n"
+        "Draw a grid (centered at (0, 0, 0))"
+    },
+    {"draw-sphere", cfun_DrawSphere, 
+        "(draw-sphere [center-x center-y center-z] radius color)\n\n"
+        "Draw sphere"
+    },
+    {"draw-sphere-ex", cfun_DrawSphereEx, 
+        "(draw-sphere-ex [center-x center-y center-z] radius rings slices color)\n\n"
+        "Draw sphere with extended parameters"
+    },
+    {"draw-sphere-wires", cfun_DrawSphereWires, 
+        "(draw-sphere-wires [center-x center-y center-z] radius rings slices color)\n\n"
+        "Draw sphere wires"
+    },
+    {"draw-cylinder", cfun_DrawCylinder, 
+        "(draw-cylinder [center-x center-y center-z] radius-top radius-bottom height slices color)\n\n"
+        "Draw a cylinder/cone"
+    },
+    {"draw-cylinder-wires", cfun_DrawCylinderWires, 
+        "(draw-cylinder-wires [center-x center-y center-z] radius-top radius-bottom height slices color)\n\n"
+        "Draw a cylinder/cone wires"
+    },
+    {"draw-plane", cfun_DrawPlane, 
+        "(draw-plane [center-x center-y center-z] [height width] color)\n\n"
+        "Draw a plane XZ"
+    },
+    {"draw-ray", cfun_DrawRay, 
+        "(draw-ray ray color)\n\n"
+        "Draw a ray line"
+    },
     {NULL, NULL, NULL}
 };

--- a/src/audio.h
+++ b/src/audio.h
@@ -327,47 +327,173 @@ static Janet cfun_SetAudioStreamPitch(int32_t argc, Janet *argv) {
 */
 
 static JanetReg audio_cfuns[] = {
-    {"init-audio-device", cfun_InitAudioDevice, NULL},
-    {"close-audio-device", cfun_CloseAudioDevice, NULL},
-    {"audio-device-ready?", cfun_IsAudioDeviceReady, NULL},
-    {"set-master-volume", cfun_SetMasterVolume, NULL},
-    {"load-wave", cfun_LoadWave, NULL},
-    {"load-sound", cfun_LoadSound, NULL},
-    {"load-sound-from-wave", cfun_LoadSoundFromWave, NULL},
-    {"unload-wave", cfun_UnloadWave, NULL},
-    {"unload-sound", cfun_UnloadSound, NULL},
-    {"export-wave", cfun_ExportWave, NULL},
-    {"export-wave-as-code", cfun_ExportWaveAsCode, NULL},
-    {"play-sound", cfun_PlaySound, NULL},
-    {"stop-sound", cfun_StopSound, NULL},
-    {"resume-sound", cfun_ResumeSound, NULL},
-    {"pause-sound", cfun_PauseSound, NULL},
-    {"sound-playing?", cfun_IsSoundPlaying, NULL},
-    {"set-sound-volume", cfun_SetSoundVolume, NULL},
-    {"set-sound-pitch", cfun_SetSoundPitch, NULL},
-    {"wave-copy", cfun_WaveCopy, NULL},
-    {"load-music-stream", cfun_LoadMusicStream, NULL},
-    {"unload-music-stream", cfun_UnloadMusicStream, NULL},
-    {"play-music-stream", cfun_PlayMusicStream, NULL},
-    {"update-music-stream", cfun_UpdateMusicStream, NULL},
-    {"pause-music-stream", cfun_PauseMusicStream, NULL},
-    {"stop-music-stream", cfun_StopMusicStream, NULL},
-    {"resume-music-stream", cfun_ResumeMusicStream, NULL},
-    {"music-stream-playing?", cfun_IsMusicStreamPlaying, NULL},
-    {"set-music-volume", cfun_SetMusicVolume, NULL},
-    {"set-music-pitch", cfun_SetMusicPitch, NULL},
-    {"get-music-time-length", cfun_GetMusicTimeLength, NULL},
-    {"get-music-time-played", cfun_GetMusicTimePlayed, NULL},
-    {"load-audio-stream", cfun_LoadAudioStream, NULL},
-    {"update-audio-stream", cfun_UpdateAudioStream, NULL},
-    {"unload-audio-stream", cfun_UnloadAudioStream, NULL},
-    {"audio-stream-processed?", cfun_IsAudioStreamProcessed, NULL},
-    {"audio-stream-playing?", cfun_IsAudioStreamPlaying, NULL},
-    {"play-audio-stream", cfun_PlayAudioStream, NULL},
-    {"pause-audio-stream", cfun_PauseAudioStream, NULL},
-    {"stop-audio-stream", cfun_StopAudioStream, NULL},
-    {"resume-audio-stream", cfun_ResumeAudioStream, NULL},
-    {"set-audio-stream-volume", cfun_SetAudioStreamVolume, NULL},
-    {"set-audio-stream-pitch", cfun_SetAudioStreamPitch, NULL},
+    {"init-audio-device", cfun_InitAudioDevice, 
+        "(init-audio-device)\n\n"
+        "Initialize audio device and context"
+    },
+    {"close-audio-device", cfun_CloseAudioDevice, 
+        "(close-audio-device)\n\n"
+        "Close the audio device and context"
+    },
+    {"audio-device-ready?", cfun_IsAudioDeviceReady, 
+        "(audio-device-ready?)\n\n"
+        "Check if audio device has been initialized successfully"
+    },
+    {"set-master-volume", cfun_SetMasterVolume, 
+        "(set-master-volume volume)\n\n"
+        "Set master volume (listener)"
+    },
+    {"load-wave", cfun_LoadWave, 
+        "(load-wave file-name)\n\n"
+        "Load wave data from file"
+    },
+    {"load-sound", cfun_LoadSound, 
+        "(load-sound file-name)\n\n"
+        "Load sound from file"
+    },
+    {"load-sound-from-wave", cfun_LoadSoundFromWave, 
+        "(load-sound-from-wave wave)\n\n"
+        "Load sound from wave data"
+    },
+    {"unload-wave", cfun_UnloadWave, 
+        "(unload-wave wave)\n\n"
+        "Unload wave data"
+    },
+    {"unload-sound", cfun_UnloadSound, 
+        "(unload-sound sound)\n\n"
+        "Unload sound"
+    },
+    {"export-wave", cfun_ExportWave, 
+        "(export-wave wave file-name)\n\n"
+        "Export wave data to file, returns true on success"
+    },
+    {"export-wave-as-code", cfun_ExportWaveAsCode, 
+        "(export-wave-as-code wave file-name)\n\n"
+        "Export wave sample data to code (.h), returns true on success"
+    },
+    {"play-sound", cfun_PlaySound, 
+        "(play-sound sound)\n\n"
+        "Play a sound"
+    },
+    {"stop-sound", cfun_StopSound, 
+        "(stop-sound sound)\n\n"
+        "Stop playing a sound"
+    },
+    {"resume-sound", cfun_ResumeSound, 
+        "(resume-sound sound)\n\n"
+        "Resume a paused sound"
+    },
+    {"pause-sound", cfun_PauseSound, 
+        "(pause-sound sound)\n\n"
+        "Pause a sound"
+    },
+    {"sound-playing?", cfun_IsSoundPlaying, 
+        "(sound-playing? sound)\n\n"
+        "Check if a sound is currently playing"
+    },
+    {"set-sound-volume", cfun_SetSoundVolume, 
+        "(set-sound-volume sound volume)\n\n"
+        "Set volume for a sound (1.0 is max level)"
+    },
+    {"set-sound-pitch", cfun_SetSoundPitch, 
+        "(set-sound-pitch sound pitch)\n\n"
+        "Set pitch for a sound (1.0 is base level)"
+    },
+    {"wave-copy", cfun_WaveCopy, 
+        "(wave-copy wave)\n\n"
+        "Copy a wave to a new wave"
+    },
+    {"load-music-stream", cfun_LoadMusicStream, 
+        "(load-music-stream file-name)\n\n"
+        "Load music stream from file"
+    },
+    {"unload-music-stream", cfun_UnloadMusicStream, 
+        "(unload-music-stream music)\n\n"
+        "Unload music stream"
+    },
+    {"play-music-stream", cfun_PlayMusicStream, 
+        "(play-music-stream music)\n\n"
+        "Start music playing"
+    },
+    {"update-music-stream", cfun_UpdateMusicStream, 
+        "(update-music-stream music)\n\n"
+        "Updates buffers for music streaming"
+    },
+    {"pause-music-stream", cfun_PauseMusicStream, 
+        "(pause-music-stream music)\n\n"
+        "Pause music playing"
+    },
+    {"stop-music-stream", cfun_StopMusicStream, 
+        "(stop-music-stream music)\n\n"
+        "Stop music playing"
+    },
+    {"resume-music-stream", cfun_ResumeMusicStream, 
+        "(resume-music-stream music)\n\n"
+        "Resume playing paused music"
+    },
+    {"music-stream-playing?", cfun_IsMusicStreamPlaying, 
+        "(music-stream-playing? music)\n\n"
+        "Check if music is playing"
+    },
+    {"set-music-volume", cfun_SetMusicVolume, 
+        "(set-music-volume music volume)\n\n"
+        "Set volume for music (1.0 is max level)"
+    },
+    {"set-music-pitch", cfun_SetMusicPitch, 
+        "(set-music-pitch music pitch)\n\n"
+        "Set pitch for a music (1.0 is base level)"
+    },
+    {"get-music-time-length", cfun_GetMusicTimeLength, 
+        "(get-music-time-length music)\n\n"
+        "Get music time length (in seconds)"
+    },
+    {"get-music-time-played", cfun_GetMusicTimePlayed, 
+        "(get-music-time-played music)\n\n"
+        "Get current music time played (in seconds)"
+    },
+    {"load-audio-stream", cfun_LoadAudioStream, 
+        "(load-audio-stream sample-rate sample-size channels)\n\n"
+        "Init audio stream (to stream raw audio pcm data)"
+    },
+    {"update-audio-stream", cfun_UpdateAudioStream, 
+        "(update-audio-stream stream)\n\n"
+        "Update audio stream buffers with data"
+    },
+    {"unload-audio-stream", cfun_UnloadAudioStream, 
+        "(unload-audio-stream stream)\n\n"
+        "Close audio stream and free memory"
+    },
+    {"audio-stream-processed?", cfun_IsAudioStreamProcessed, 
+        "(audio-stream-processed? stream)\n\n"
+        "Check if any audio stream buffers requires refill"
+    },
+    {"audio-stream-playing?", cfun_IsAudioStreamPlaying, 
+        "(audio-stream-playing? stream)\n\n"
+        "Check if audio stream is playing"
+    },
+    {"play-audio-stream", cfun_PlayAudioStream, 
+        "(play-audio-stream stream)\n\n"
+        "Play audio stream"
+    },
+    {"pause-audio-stream", cfun_PauseAudioStream, 
+        "(pause-audio-stream stream)\n\n"
+        "Pause audio stream"
+    },
+    {"stop-audio-stream", cfun_StopAudioStream, 
+        "(stop-audio-stream stream)\n\n"
+        "Stop audio stream"
+    },
+    {"resume-audio-stream", cfun_ResumeAudioStream, 
+        "(resume-audio-stream stream)\n\n"
+        "Resume audio stream"
+    },
+    {"set-audio-stream-volume", cfun_SetAudioStreamVolume, 
+        "(set-audio-stream-volume stream volume)\n\n"
+        "Set volume for audio stream (1.0 is max level)"
+    },
+    {"set-audio-stream-pitch", cfun_SetAudioStreamPitch, 
+        "(set-audio-stream-pitch stream pitch)\n\n"
+        "Set pitch for audio stream (1.0 is base level)"
+    },
     {NULL, NULL, NULL}
 };

--- a/src/core.h
+++ b/src/core.h
@@ -861,98 +861,388 @@ static Janet cfun_SetCameraMoveControls(int32_t argc, Janet *argv) {
 }
 
 static JanetReg core_cfuns[] = {
-    {"init-window", cfun_InitWindow, NULL},
-    {"window-should-close", cfun_WindowShouldClose, NULL},
-    {"close-window", cfun_CloseWindow, NULL},
-    {"window-ready?", cfun_IsWindowReady, NULL},
-    {"window-minimized?", cfun_IsWindowMinimized, NULL},
-    {"window-resized?", cfun_IsWindowResized, NULL},
-    {"window-state?", cfun_IsWindowState, NULL},
-    {"set-window-state", cfun_SetWindowState, NULL},
-    {"clear-window-state", cfun_ClearWindowState, NULL},
-    {"toggle-fullscreen", cfun_ToggleFullscreen, NULL},
-    {"set-window-title", cfun_SetWindowTitle, NULL},
-    {"set-window-position", cfun_SetWindowPosition, NULL},
-    {"set-window-monitor", cfun_SetWindowMonitor, NULL},
-    {"set-window-min-size", cfun_SetWindowMinSize, NULL},
-    {"set-window-size", cfun_SetWindowSize, NULL},
-    {"get-window-handle", cfun_GetWindowHandle, NULL},
-    {"get-screen-width", cfun_GetScreenWidth, NULL},
-    {"get-screen-height", cfun_GetScreenHeight, NULL},
-    {"get-monitor-count", cfun_GetMonitorCount, NULL},
-    {"get-monitor-width", cfun_GetMonitorWidth, NULL},
-    {"get-monitor-height", cfun_GetMonitorHeight, NULL},
-    {"get-monitor-physical-width", cfun_GetMonitorPhysicalWidth, NULL},
-    {"get-monitor-physical-height", cfun_GetMonitorPhysicalHeight, NULL},
-    {"get-monitor-name", cfun_GetMonitorName, NULL},
-    {"get-clipboard-text", cfun_GetClipboardText, NULL},
-    {"set-clipboard-text", cfun_SetClipboardText, NULL},
-    {"show-cursor", cfun_ShowCursor, NULL},
-    {"hide-cursor", cfun_HideCursor, NULL},
-    {"cursor-hidden?", cfun_IsCursorHidden, NULL},
-    {"enable-cursor", cfun_EnableCursor, NULL},
-    {"disable-cursor", cfun_DisableCursor, NULL},
-    {"cursor-on-screen?", cfun_IsCursorOnScreen, NULL},
-    {"clear-background", cfun_ClearBackground, NULL},
-    {"begin-drawing", cfun_BeginDrawing, NULL},
-    {"end-drawing", cfun_EndDrawing, NULL},
-    {"begin-mode-2d", cfun_BeginMode2D, NULL},
-    {"end-mode-2d", cfun_EndMode2D, NULL},
-    {"set-target-fps", cfun_SetTargetFPS, NULL},
-    {"get-fps", cfun_GetFPS, NULL},
-    {"get-frame-time", cfun_GetFrameTime, NULL},
-    {"get-time", cfun_GetTime, NULL},
-    {"set-config-flags", cfun_SetConfigFlags, NULL},
-    {"set-trace-log-level", cfun_SetTraceLogLevel, NULL},
-    {"set-trace-log-callback", cfun_SetTraceLogCallback, NULL},
-    {"trace-log", cfun_TraceLog, NULL},
-    {"take-screenshot", cfun_TakeScreenshot, NULL},
-    {"key-pressed?", cfun_IsKeyPressed, NULL},
-    {"key-released?", cfun_IsKeyReleased, NULL},
-    {"key-up?", cfun_IsKeyUp, NULL},
-    {"key-down?", cfun_IsKeyDown, NULL},
-    {"get-key-pressed", cfun_GetKeyPressed, NULL},
-    {"set-exit-key", cfun_SetExitKey, NULL},
-    {"gamepad-available?", cfun_IsGamepadAvailable, NULL},
-    {"gamepad-button-down?", cfun_IsGamepadButtonDown, NULL},
-    {"gamepad-button-up?", cfun_IsGamepadButtonUp, NULL},
-    {"gamepad-button-pressed?", cfun_IsGamepadButtonPressed, NULL},
-    {"gamepad-button-released?", cfun_IsGamepadButtonReleased, NULL},
-    {"get-gamepad-button-pressed", cfun_GetGamepadButtonPressed, NULL},
-    {"get-gamepad-name", cfun_GetGamepadName, NULL},
-    {"get-gamepad-axis-count", cfun_GetGamepadAxisCount, NULL},
-    {"get-gamepad-axis-movement", cfun_GetGamepadAxisMovement, NULL},
-    {"mouse-button-pressed?", cfun_IsMouseButtonPressed, NULL},
-    {"mouse-button-up?", cfun_IsMouseButtonUp, NULL},
-    {"mouse-button-released?", cfun_IsMouseButtonReleased, NULL},
-    {"mouse-button-down?", cfun_IsMouseButtonDown, NULL},
-    {"get-mouse-x", cfun_GetMouseX, NULL},
-    {"get-mouse-y", cfun_GetMouseY, NULL},
-    {"get-mouse-position", cfun_GetMousePosition, NULL},
-    {"set-mouse-position", cfun_SetMousePosition, NULL},
-    {"set-mouse-offset", cfun_SetMouseOffset, NULL},
-    {"set-mouse-scale", cfun_SetMouseScale, NULL},
-    {"get-mouse-wheel-move", cfun_GetMouseWheelMove, NULL},
-    {"get-touch-x", cfun_GetTouchX, NULL},
-    {"get-touch-y", cfun_GetTouchY, NULL},
-    {"get-touch-position", cfun_GetTouchPosition, NULL},
-    {"get-dropped-files", cfun_GetDroppedFiles, NULL},
-    {"clear-dropped-files", cfun_ClearDroppedFiles, NULL},
-    {"save-storage-value", cfun_SaveStorageValue, NULL},
-    {"load-storage-value", cfun_LoadStorageValue, NULL},
-    {"open-url", cfun_OpenUrl, NULL},
-    {"set-window-icon", cfun_SetWindowIcon, NULL},
-    {"begin-mode-3d", cfun_BeginMode3D, NULL},
-    {"end-mode-3d", cfun_EndMode3D, NULL},
-    {"begin-texture-mode", cfun_BeginTextureMode, NULL},
-    {"end-texture-mode", cfun_EndTextureMode, NULL},
-    {"camera-2d", cfun_Camera2D, NULL},
-    {"camera-3d", cfun_Camera3D, NULL},
-    {"set-camera-mode", cfun_SetCameraMode, NULL},
-    {"update-camera", cfun_UpdateCamera, NULL},
-    {"set-camera-pan-control", cfun_SetCameraPanControl, NULL},
-    {"set-camera-alt-control", cfun_SetCameraAltControl, NULL},
-    {"set-camera-smooth-zoom-control", cfun_SetCameraSmoothZoomControl, NULL},
-    {"set-camera-move-controls", cfun_SetCameraMoveControls, NULL},
+    {"init-window", cfun_InitWindow, 
+        "(init-window width height title)\n\n" 
+        "Initialize window and OpenGL context"
+    },
+    {"window-should-close", cfun_WindowShouldClose, 
+        "(window-should-close)\n\n" 
+        "Check if KEY_ESCAPE pressed or Close icon pressed"
+    },
+    {"close-window", cfun_CloseWindow, 
+        "(close-window)\n\n" 
+        "Close window and unload OpenGL context"
+    },
+    {"window-ready?", cfun_IsWindowReady, 
+        "(window-ready?)\n\n" 
+        "Check if window has been initialized successfully"
+    },
+    {"window-minimized?", cfun_IsWindowMinimized, 
+        "(window-minimized?)\n\n" 
+        "Check if window is currently minimized"
+    },
+    {"window-resized?", cfun_IsWindowResized, 
+        "(window-resized?)\n\n" 
+        "Check if window has been resized last frame"
+    },
+    {"window-state?", cfun_IsWindowState, 
+        "(window-state? flag)\n\n" 
+        "Check if one specific window flag is enabled"
+    },
+    {"set-window-state", cfun_SetWindowState, 
+        "(set-window-state flags)\n\n" 
+        "Set window configuration state using flags"
+    },
+    {"clear-window-state", cfun_ClearWindowState, 
+        "(clear-window-state flags)\n\n" 
+        "Clear window configuration state flags"
+    },
+    {"toggle-fullscreen", cfun_ToggleFullscreen, 
+        "(toggle-fullscreen)\n\n" 
+        "Toggle window state: fullscreen/windowed"
+    },
+    {"set-window-title", cfun_SetWindowTitle, 
+        "(set-window-title title)\n\n" 
+        "Set title for window"
+    },
+    {"set-window-position", cfun_SetWindowPosition, 
+        "(set-window-position x y)\n\n" 
+        "Set window position on screen"
+    },
+    {"set-window-monitor", cfun_SetWindowMonitor, 
+        "(set-window-monitor monitor)\n\n" 
+        "Set monitor for the current window"
+    },
+    {"set-window-min-size", cfun_SetWindowMinSize, 
+        "(set-window-min-size width height)\n\n" 
+        "Set window minimum dimensions"
+    },
+    {"set-window-size", cfun_SetWindowSize, 
+        "(set-window-size width height)\n\n" 
+        "Set window dimensions"
+    },
+    {"get-window-handle", cfun_GetWindowHandle, 
+        "(get-window-handle)\n\n" 
+        "Get native window handle"
+    },
+    {"get-screen-width", cfun_GetScreenWidth, 
+        "(get-screen-width)\n\n" 
+        "Get current screen width"
+    },
+    {"get-screen-height", cfun_GetScreenHeight, 
+        "(get-screen-height)\n\n" 
+        "Get current screen height"
+    },
+    {"get-monitor-count", cfun_GetMonitorCount, 
+        "(get-monitor-count)\n\n" 
+        "Get number of connected monitors"
+    },
+    {"get-monitor-width", cfun_GetMonitorWidth, 
+        "(get-monitor-width monitor)\n\n" 
+        "Get specified monitor width (max available by monitor)"
+    },
+    {"get-monitor-height", cfun_GetMonitorHeight, 
+        "(get-monitor-height monitor)\n\n" 
+        "Get specified monitor height (max available by monitor)"
+    },
+    {"get-monitor-physical-width", cfun_GetMonitorPhysicalWidth, 
+        "(get-monitor-physical-width monitor)\n\n" 
+        "Get specified monitor physical width in millimetres"
+    },
+    {"get-monitor-physical-height", cfun_GetMonitorPhysicalHeight, 
+        "(get-monitor-physical-height monitor)\n\n" 
+        "Get specified monitor physical height in millimetres"
+    },
+    {"get-monitor-name", cfun_GetMonitorName, 
+        "(get-monitor-name monitor)\n\n" 
+        "Get the human-readable, UTF-8 encoded name of the primary monitor"
+    },
+    {"get-clipboard-text", cfun_GetClipboardText, 
+        "(get-clipboard-text)\n\n" 
+        "Get clipboard text content"
+    },
+    {"set-clipboard-text", cfun_SetClipboardText, 
+        "(set-clipboard-text text)\n\n" 
+        "Set clipboard text content"
+    },
+    {"show-cursor", cfun_ShowCursor, 
+        "(show-cursor)\n\n" 
+        "Shows cursor"
+    },
+    {"hide-cursor", cfun_HideCursor, 
+        "(hide-cursor)\n\n" 
+        "Hides cursor"
+    },
+    {"cursor-hidden?", cfun_IsCursorHidden, 
+        "(cursor-hidden?)\n\n" 
+        "Check if cursor is not visible"
+    },
+    {"enable-cursor", cfun_EnableCursor, 
+        "(enable-cursor)\n\n" 
+        "Enables cursor (unlock cursor)"
+    },
+    {"disable-cursor", cfun_DisableCursor, 
+        "(disable-cursor)\n\n" 
+        "Disables cursor (lock cursor)"
+    },
+    {"cursor-on-screen?", cfun_IsCursorOnScreen, 
+        "(cursor-on-screen?)\n\n" 
+        "Check if cursor is on the screen"
+    },
+    {"clear-background", cfun_ClearBackground, 
+        "(clear-background color)\n\n" 
+        "Set background color (framebuffer clear color)"
+    },
+    {"begin-drawing", cfun_BeginDrawing, 
+        "(begin-drawing)\n\n" 
+        "Setup canvas (framebuffer) to start drawing"
+    },
+    {"end-drawing", cfun_EndDrawing, 
+        "(end-drawing)\n\n" 
+        "End canvas drawing and swap buffers (double buffering)"
+    },
+    {"begin-mode-2d", cfun_BeginMode2D, 
+        "(begin-mode-2d camera)\n\n" 
+        "Begin 2D mode with custom camera (2D)"
+    },
+    {"end-mode-2d", cfun_EndMode2D, 
+        "(end-mode-2d)\n\n" 
+        "Ends 2D mode with custom camera"
+    },
+    {"set-target-fps", cfun_SetTargetFPS, 
+        "(set-target-fps fps)\n\n" 
+        "Set target FPS (maximum)"
+    },
+    {"get-fps", cfun_GetFPS, 
+        "(get-fps)\n\n" 
+        "Get current FPS"
+    },
+    {"get-frame-time", cfun_GetFrameTime, 
+        "(get-frame-time)\n\n" 
+        "Get time in seconds for last frame drawn (delta time)"
+    },
+    {"get-time", cfun_GetTime, 
+        "(get-time)\n\n" 
+        "Get elapsed time in seconds since InitWindow()"
+    },
+    {"set-config-flags", cfun_SetConfigFlags, 
+        "(set-config-flags flags)\n\n" 
+        "Setup init configuration flags (view FLAGS)"
+    },
+    {"set-trace-log-level", cfun_SetTraceLogLevel, 
+        "(set-trace-log-level log-level)\n\n" 
+        "Set the current threshold (minimum) log level"
+    },
+    {"set-trace-log-callback", cfun_SetTraceLogCallback, 
+        "(set-trace-log-callback callback)\n\n" 
+        "Set custom trace log"
+    },
+    {"trace-log", cfun_TraceLog, 
+        "(trace-log log-level text)\n\n" 
+        "Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)"
+    },
+    {"take-screenshot", cfun_TakeScreenshot, 
+        "(take-screenshot file-name)\n\n" 
+        "Takes a screenshot of current screen (filename extension defines format)"
+    },
+    {"key-pressed?", cfun_IsKeyPressed, 
+        "(key-pressed? key)\n\n" 
+        "Check if a key has been pressed once"
+    },
+    {"key-released?", cfun_IsKeyReleased, 
+        "(key-released? key)\n\n" 
+        "Check if a key has been released once"
+    },
+    {"key-up?", cfun_IsKeyUp, 
+        "(key-up? key)\n\n" 
+        "Check if a key is NOT being pressed"
+    },
+    {"key-down?", cfun_IsKeyDown, 
+        "(key-down? key)\n\n" 
+        "Check if a key is being pressed"
+    },
+    {"get-key-pressed", cfun_GetKeyPressed, 
+        "(get-key-pressed)\n\n" 
+        "Get key pressed (keycode), call it multiple times for keys "
+        "queued, returns 0 when the queue is empty"
+    },
+    {"set-exit-key", cfun_SetExitKey, 
+        "(set-exit-key key)\n\n" 
+        "Set a custom key to exit program (default is ESC)"
+    },
+    {"gamepad-available?", cfun_IsGamepadAvailable, 
+        "(gamepad-available? gamepad)\n\n" 
+        "Check if a gamepad is available"
+    },
+    {"gamepad-button-down?", cfun_IsGamepadButtonDown, 
+        "(gamepad-button-down? gamepad button)\n\n" 
+        "Check if a gamepad button is being pressed"
+    },
+    {"gamepad-button-up?", cfun_IsGamepadButtonUp, 
+        "(gamepad-button-up? gamepad button)\n\n" 
+        "Check if a gamepad button is NOT being pressed"
+    },
+    {"gamepad-button-pressed?", cfun_IsGamepadButtonPressed, 
+        "(gamepad-button-pressed? gamepad button)\n\n" 
+        "Check if a gamepad button has been pressed once"
+    },
+    {"gamepad-button-released?", cfun_IsGamepadButtonReleased, 
+        "(gamepad-button-released? gamepad button)\n\n" 
+        "Check if a gamepad button has been released once"
+    },
+    {"get-gamepad-button-pressed", cfun_GetGamepadButtonPressed, 
+        "(get-gamepad-button-pressed)\n\n" 
+        "Get the last gamepad button pressed"
+    },
+    {"get-gamepad-name", cfun_GetGamepadName, 
+        "(get-gamepad-name gamepad)\n\n" 
+        "Get gamepad internal name id"
+    },
+    {"get-gamepad-axis-count", cfun_GetGamepadAxisCount, 
+        "(get-gamepad-axis-count gamepad)\n\n" 
+        "Get gamepad axis count for a gamepad"
+    },
+    {"get-gamepad-axis-movement", cfun_GetGamepadAxisMovement, 
+        "(get-gamepad-axis-movement gamepad axis)\n\n" 
+        "Get axis movement value for a gamepad axis"
+    },
+    {"mouse-button-pressed?", cfun_IsMouseButtonPressed, 
+        "(mouse-button-pressed? button)\n\n" 
+        "Check if a mouse button has been pressed once"
+    },
+    {"mouse-button-up?", cfun_IsMouseButtonUp, 
+        "(mouse-button-up? button)\n\n" 
+        "Check if a mouse button is NOT being pressed"
+    },
+    {"mouse-button-released?", cfun_IsMouseButtonReleased, 
+        "(mouse-button-released? button)\n\n" 
+        "Check if a mouse button has been released once"
+    },
+    {"mouse-button-down?", cfun_IsMouseButtonDown, 
+        "(mouse-button-down? button)\n\n" 
+        "Check if a mouse button is being pressed"
+    },
+    {"get-mouse-x", cfun_GetMouseX, 
+        "(get-mouse-x)\n\n" 
+        "Get mouse position X"
+    },
+    {"get-mouse-y", cfun_GetMouseY, 
+        "(get-mouse-y)\n\n" 
+        "Get mouse position Y"
+    },
+    {"get-mouse-position", cfun_GetMousePosition, 
+        "(get-mouse-position)\n\n" 
+        "Get mouse position XY"
+    },
+    {"set-mouse-position", cfun_SetMousePosition, 
+        "(set-mouse-position x y)\n\n" 
+        "Set mouse position XY"
+    },
+    {"set-mouse-offset", cfun_SetMouseOffset, 
+        "(set-mouse-offset offset-x offset-y)\n\n" 
+        "Set mouse offset"
+    },
+    {"set-mouse-scale", cfun_SetMouseScale, 
+        "(set-mouse-scale scale-x scale-y)\n\n" 
+        "Set mouse scaling"
+    },
+    {"get-mouse-wheel-move", cfun_GetMouseWheelMove, 
+        "(get-mouse-wheel-move)\n\n" 
+        "Get mouse wheel movement Y"
+    },
+    {"get-touch-x", cfun_GetTouchX, 
+        "(get-touch-x)\n\n" 
+        "Get touch position X for touch point 0 (relative to screen size)"
+    },
+    {"get-touch-y", cfun_GetTouchY, 
+        "(get-touch-y)\n\n" 
+        "Get touch position Y for touch point 0 (relative to screen size)"
+    },
+    {"get-touch-position", cfun_GetTouchPosition, 
+        "(get-touch-position index)\n\n" 
+        "Get touch position XY for a touch point index (relative to screen size)"
+    },
+    {"get-dropped-files", cfun_GetDroppedFiles, 
+        "(get-dropped-files count)\n\n" 
+        "Get dropped files names (memory should be freed)"
+    },
+    {"clear-dropped-files", cfun_ClearDroppedFiles, 
+        "(clear-dropped-files)\n\n" 
+        "Clear dropped files paths buffer (free memory)"
+    },
+    {"save-storage-value", cfun_SaveStorageValue, 
+        "(save-storage-value position value)\n\n" 
+        "Save integer value to storage file (to defined position), "
+        "returns true on success"
+    },
+    {"load-storage-value", cfun_LoadStorageValue, 
+        "(load-storage-value position)\n\n" 
+        "Load integer value from storage file (from defined position)"
+    },
+    {"open-url", cfun_OpenUrl, 
+        "(open-url url)\n\n" 
+        "Open URL with default system browser (if available)"
+    },
+    {"set-window-icon", cfun_SetWindowIcon, 
+        "(set-window-icon image)\n\n" 
+        "Set icon for window"
+    },
+    {"begin-mode-3d", cfun_BeginMode3D, 
+        "(begin-mode-3d camera)\n\n" 
+        "Begin 3D mode with custom camera (3D)"
+    },
+    {"end-mode-3d", cfun_EndMode3D, 
+        "(end-mode-3d)\n\n" 
+        "Ends 3D mode and returns to default 2D orthographic mode"
+    },
+    {"begin-texture-mode", cfun_BeginTextureMode, 
+        "(begin-texture-mode target)\n\n" 
+        "Begin drawing to render texture"
+    },
+    {"end-texture-mode", cfun_EndTextureMode, 
+        "(end-texture-mode)\n\n" 
+        "Ends drawing to render texture"
+    },
+    {"camera-2d", cfun_Camera2D, 
+        "(camera-2d &opt :offset [x y] :target [x y] :rotation int :zoom float)\n\n" 
+        "Instantiate a Camera2D. \n"
+        " - :offset   = Camera offset (displacement from target) \n"
+        " - :target   = Camera target (rotation and zoom origin) \n"
+        " - :rotation = Camera rotation in degrees \n"
+        " - :zoom     = Camera zoom (scaling), should be 1.0f by default \n"
+    },
+    {"camera-3d", cfun_Camera3D, 
+        "(camera-3d :position [x y z] :target [x y z] :up [x y z] :fov-y float :projection int)\n\n" 
+        "Instantiate a Camera3D. \n"
+        " - :position   = Camera position \n"
+        " - :target     = Camera target it looks-at \n"
+        " - :up         = Camera up vector (rotation over its axis) \n"
+        " - :fov-y      = Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic \n"
+        " - :projection = Camera projection: CAMERA\\_PERSPECTIVE or CAMERA\\_ORTHOGRAPHIC \n"
+    },
+    {"set-camera-mode", cfun_SetCameraMode, 
+        "(set-camera-mode camera mode)\n\n" 
+        "Set camera mode (multiple camera modes available)"
+    },
+    {"update-camera", cfun_UpdateCamera, 
+        "(update-camera camera)\n\n" 
+        "Update camera position for selected mode"
+    },
+    {"set-camera-pan-control", cfun_SetCameraPanControl, 
+        "(set-camera-pan-control key-pan)\n\n" 
+        "Set camera pan key to combine with mouse movement (free camera)"
+    },
+    {"set-camera-alt-control", cfun_SetCameraAltControl, 
+        "(set-camera-alt-control key-alt)\n\n" 
+        "Set camera alt key to combine with mouse movement (free camera)"
+    },
+    {"set-camera-smooth-zoom-control", cfun_SetCameraSmoothZoomControl, 
+        "(set-camera-smooth-zoom-control key-smooth-zoom)\n\n" 
+        "Set camera smooth zoom key to combine with mouse (free camera)"
+    },
+    {"set-camera-move-controls", cfun_SetCameraMoveControls, 
+        "(set-camera-move-controls key-front key-back key-right key-left key-up key-down)\n\n" 
+        "Set camera move controls (1st person and 3rd person cameras)"
+    },
     {NULL, NULL, NULL}
 };

--- a/src/gestures.h
+++ b/src/gestures.h
@@ -106,14 +106,41 @@ static Janet cfun_GetGesturePinchAngle(int32_t argc, Janet *argv) {
 }
 
 static JanetReg gesture_cfuns[] = {
-    {"set-gestures-enabled", cfun_SetGesturesEnabled, NULL},
-    {"gesture-detected?", cfun_IsGestureDetected, NULL},
-    {"get-gesture-detected", cfun_GetGestureDetected, NULL},
-    {"get-touch-point-count", cfun_GetTouchPointCount, NULL},
-    {"get-gesture-hold-duration", cfun_GetGestureHoldDuration, NULL},
-    {"get-gesture-drag-vector", cfun_GetGestureDragVector, NULL},
-    {"get-gesture-drag-angle", cfun_GetGestureDragAngle, NULL},
-    {"get-gesture-pinch-vector", cfun_GetGesturePinchVector, NULL},
-    {"get-gesture-pinch-angle", cfun_GetGesturePinchAngle, NULL},
+    {"set-gestures-enabled", cfun_SetGesturesEnabled, 
+        "(set-gestures-enabled flags)\n\n"
+        "Enable a set of gestures using flags"
+    },
+    {"gesture-detected?", cfun_IsGestureDetected, 
+        "(gesture-detected? gesture)\n\n"
+        "Check if a gesture have been detected"
+    },
+    {"get-gesture-detected", cfun_GetGestureDetected, 
+        "(get-gesture-detected)\n\n"
+        "Get latest detected gesture"
+    },
+    {"get-touch-point-count", cfun_GetTouchPointCount, 
+        "(get-touch-point-count)\n\n"
+        "Get number of touch points"
+    },
+    {"get-gesture-hold-duration", cfun_GetGestureHoldDuration, 
+        "(get-gesture-hold-duration)\n\n"
+        "Get gesture hold time in milliseconds"
+    },
+    {"get-gesture-drag-vector", cfun_GetGestureDragVector, 
+        "(get-gesture-drag-vector)\n\n"
+        "Get gesture drag vector"
+    },
+    {"get-gesture-drag-angle", cfun_GetGestureDragAngle, 
+        "(get-gesture-drag-angle)\n\n"
+        "Get gesture drag angle"
+    },
+    {"get-gesture-pinch-vector", cfun_GetGesturePinchVector, 
+        "(get-gesture-pinch-vector)\n\n"
+        "Get gesture pinch delta"
+    },
+    {"get-gesture-pinch-angle", cfun_GetGesturePinchAngle, 
+        "(get-gesture-pinch-angle)\n\n"
+        "Get gesture pinch angle"
+    },
     {NULL, NULL, NULL}
 };

--- a/src/image.h
+++ b/src/image.h
@@ -632,68 +632,257 @@ RLAPI void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle
 */
 
 static const JanetReg image_cfuns[] = {
-    {"load-image-1", cfun_LoadImage, NULL}, // load-image is janet core function, don't want to overwrite if we use (use jaylib)
-    {"export-image", cfun_ExportImage, NULL},
-    {"export-image-as-code", cfun_ExportImageAsCode, NULL},
-    {"load-texture", cfun_LoadTexture, NULL},
-    {"load-texture-from-image", cfun_LoadTextureFromImage,  NULL},
-    {"load-texture-cubemap", cfun_LoadTextureCubemap, NULL},
-    {"load-render-texture", cfun_LoadRenderTexture, NULL},
-    {"unload-image", cfun_UnloadImage, NULL},
-    {"unload-texture", cfun_UnloadTexture, NULL},
-    {"unload-render-texture", cfun_UnloadRenderTexture, NULL},
-    {"get-image-dimensions", cfun_GetImageDimensions, NULL},
-    {"load-image-from-texture", cfun_LoadImageFromTexture, NULL},
-    {"load-image-from-screen", cfun_LoadImageFromScreen, NULL},
-    {"get-render-texture-texture2d", cfun_GetRenderTextureTexture2d, NULL},
-    {"image-copy", cfun_ImageCopy, NULL},
-    {"image-from-image", cfun_ImageFromImage, NULL},
-    {"image-to-pot", cfun_ImageToPOT, NULL},
-    {"image-format", cfun_ImageFormat, NULL},
-    {"image-alpha-mask", cfun_ImageAlphaMask, NULL},
-    {"image-alpha-clear", cfun_ImageAlphaClear, NULL},
-    {"image-alpha-crop", cfun_ImageAlphaCrop, NULL},
-    {"image-alpha-premultiply", cfun_ImageAlphaPremultiply, NULL},
-    {"image-crop", cfun_ImageCrop, NULL},
-    {"image-resize", cfun_ImageResize, NULL},
-    {"image-resize-nn", cfun_ImageResizeNN, NULL},
-    {"image-resize-canvas", cfun_ImageResizeCanvas, NULL},
-    {"image-mipmaps", cfun_ImageMipmaps, NULL},
-    {"image-dimensions", cfun_ImageDimensions, NULL},
-    {"image-dither", cfun_ImageDither, NULL},
-    {"load-image-pallete", cfun_LoadImagePalette, NULL},
-    {"image-text", cfun_ImageText, NULL},
-    {"image-text-ex", cfun_ImageTextEx, NULL},
-    {"image-draw", cfun_ImageDraw, NULL},
-    {"image-draw-rectangle-rec", cfun_ImageDrawRectangleRec, NULL},
-    {"image-draw-rectangle-lines", cfun_ImageDrawRectangleLines, NULL},
-    {"image-draw-text", cfun_ImageDrawText, NULL},
-    {"image-draw-text-ex", cfun_ImageDrawTextEx, NULL},
-    {"image-flip-vertical", cfun_ImageFlipVertical, NULL},
-    {"image-flip-horizontal", cfun_ImageFlipHorizontal, NULL},
-    {"image-rotate-cw", cfun_ImageRotateCW, NULL},
-    {"image-rotate-ccw", cfun_ImageRotateCCW, NULL},
-    {"image-color-tint", cfun_ImageColorTint, NULL},
-    {"image-color-invert", cfun_ImageColorInvert, NULL},
-    {"image-color-grayscale", cfun_ImageColorGrayscale, NULL},
-    {"image-color-brightness", cfun_ImageColorBrightness, NULL},
-    {"image-color-contrast", cfun_ImageColorContrast, NULL},
-    {"image-color-replace", cfun_ImageColorReplace, NULL},
-    {"draw-texture", cfun_DrawTexture, NULL},
-    {"draw-texture-v", cfun_DrawTextureV, NULL},
-    {"draw-texture-ex", cfun_DrawTextureEx, NULL},
-    {"draw-texture-pro", cfun_DrawTexturePro, NULL},
-    {"draw-texture-quad", cfun_DrawTextureQuad, NULL},
-    {"draw-texture-rec", cfun_DrawTextureRec, NULL},
-    {"gen-image-color", cfun_GenImageColor, NULL},
-    {"gen-image-gradient-v", cfun_GenImageGradientV, NULL},
-    {"gen-image-gradient-h", cfun_GenImageGradientH, NULL},
-    {"gen-image-gradient-radial", cfun_GenImageGradientRadial, NULL},
-    {"gen-image-checked", cfun_GenImageChecked, NULL},
-    {"gen-image-white-noise", cfun_GenImageWhiteNoise, NULL},
-    {"gen-image-cellular", cfun_GenImageCellular, NULL},
-    {"gen-texture-mipmaps", cfun_GenTextureMipmaps, NULL},
-    {"set-texture-filter", cfun_SetTextureFilter, NULL},
-    {"set-texture-wrap", cfun_SetTextureWrap, NULL},
+    {"load-image-1", cfun_LoadImage, 
+        "(load-image-1 file-name)\n\n"
+        "Load image from file into CPU memory (RAM)"
+    }, // load-image is janet core function, don't want to overwrite if we use (use jaylib)
+    {"export-image", cfun_ExportImage, 
+        "(export-image image file-name)\n\n"
+        "Export image data to file, returns true on success"
+    },
+    {"export-image-as-code", cfun_ExportImageAsCode, 
+        "(export-image-as-code image file-name)\n\n"
+        "Export image as code file defining an array of bytes, returns true on success"
+    },
+    {"load-texture", cfun_LoadTexture, 
+        "(load-texture file-name)\n\n"
+        "Load texture from file into GPU memory (VRAM)"
+    },
+    {"load-texture-from-image", cfun_LoadTextureFromImage,  
+        "(load-texture-from-image image)\n\n"
+        "Load texture from image data"
+    },
+    {"load-texture-cubemap", cfun_LoadTextureCubemap, 
+        "(load-texture-cubemap image layout)\n\n"
+        "Load cubemap from image, multiple image cubemap layouts supported"
+    },
+    {"load-render-texture", cfun_LoadRenderTexture, 
+        "(load-render-texture width height)\n\n"
+        "Load texture for rendering (framebuffer)"
+    },
+    {"unload-image", cfun_UnloadImage, 
+        "(unload-image image)\n\n"
+        "Unload image from CPU memory (RAM)"
+    },
+    {"unload-texture", cfun_UnloadTexture, 
+        "(unload-texture texture)\n\n"
+        "Unload texture from GPU memory (VRAM)"
+    },
+    {"unload-render-texture", cfun_UnloadRenderTexture, 
+        "(unload-render-texture target)\n\n"
+        "Unload render texture from GPU memory (VRAM)"
+    },
+    {"get-image-dimensions", cfun_GetImageDimensions, 
+        "(get-image-dimensions image)\n\n"
+        "Get image dimensions."
+    },
+    {"load-image-from-texture", cfun_LoadImageFromTexture, 
+        "(load-image-from-texture texture)\n\n"
+        "Load image from GPU texture data"
+    },
+    {"load-image-from-screen", cfun_LoadImageFromScreen, 
+        "(load-image-from-screen)\n\n"
+        "Load image from screen buffer and (screenshot)"
+    },
+    {"get-render-texture-texture2d", cfun_GetRenderTextureTexture2d, 
+        "(get-render-texture-texture2d texture)\n\n"
+        "Load texture for rendering (framebuffer)"
+    },
+    {"image-copy", cfun_ImageCopy, 
+        "(image-copy image)\n\n"
+        "Create an image duplicate (useful for transformations)"
+    },
+    {"image-from-image", cfun_ImageFromImage, 
+        "(image-from-image image rec)\n\n"
+        "Create an image from another image piece"
+    },
+    {"image-to-pot", cfun_ImageToPOT, 
+        "(image-to-pot image fill)\n\n"
+        "Convert image to POT (power-of-two)"
+    },
+    {"image-format", cfun_ImageFormat, 
+        "(image-format image new-format)\n\n"
+        "Convert image data to desired format"
+    },
+    {"image-alpha-mask", cfun_ImageAlphaMask, 
+        "(image-alpha-mask image alpha-mask)\n\n"
+        "Apply alpha mask to image"
+    },
+    {"image-alpha-clear", cfun_ImageAlphaClear, 
+        "(image-alpha-clear image clear threshold)\n\n"
+        "Clear alpha channel to desired color"
+    },
+    {"image-alpha-crop", cfun_ImageAlphaCrop, 
+        "(image-alpha-crop image threshold)\n\n"
+        "Crop image depending on alpha value"
+    },
+    {"image-alpha-premultiply", cfun_ImageAlphaPremultiply, 
+        "(image-alpha-premultiply image)\n\n"
+        "Premultiply alpha channel"
+    },
+    {"image-crop", cfun_ImageCrop, 
+        "(image-crop image crop)\n\n"
+        "Crop an image to a defined rectangle"
+    },
+    {"image-resize", cfun_ImageResize, 
+        "(image-resize image new-width new-height)\n\n"
+        "Resize image (Bicubic scaling algorithm)"
+    },
+    {"image-resize-nn", cfun_ImageResizeNN, 
+        "(image-resize-nn image new-width new-height)\n\n"
+        "Resize image (Nearest-Neighbor scaling algorithm)"
+    },
+    {"image-resize-canvas", cfun_ImageResizeCanvas, 
+        "(image-resize-canvas image new-width new-height offset-x offset-y fill)\n\n"
+        "Resize canvas and fill with color"
+    },
+    {"image-mipmaps", cfun_ImageMipmaps, 
+        "(image-mipmaps image)\n\n"
+        "Generate all mipmap levels for a provided image"
+    },
+    {"image-dimensions", cfun_ImageDimensions, 
+        "(image-dimensions image)\n\n"
+        "Get image dimensions"
+    },
+    {"image-dither", cfun_ImageDither, 
+        "(image-dither image r-bpp g-bpp b-bpp a-bpp)\n\n"
+        "Dither image data to 16bpp or lower (Floyd-Steinberg dithering)"
+    },
+    {"load-image-pallete", cfun_LoadImagePalette, 
+        "(load-image-pallete image max-palette-size colors-count)\n\n"
+        "Load colors palette from image as a Color array (RGBA - 32bit)"
+    },
+    {"image-text", cfun_ImageText, 
+        "(image-text text font-size color)\n\n"
+        "Create an image from text (default font)"
+    },
+    {"image-text-ex", cfun_ImageTextEx, 
+        "(image-text-ex font text font-size spacing tint)\n\n"
+        "Create an image from text (custom sprite font)"
+    },
+    {"image-draw", cfun_ImageDraw, 
+        "(image-draw dst src src-rec dst-rec tint)\n\n"
+        "Draw a source image within a destination image (tint applied to source)"
+    },
+    {"image-draw-rectangle-rec", cfun_ImageDrawRectangleRec, 
+        "(image-draw-rectangle-rec dst rec color)\n\n"
+        "Draw rectangle within an image"
+    },
+    {"image-draw-rectangle-lines", cfun_ImageDrawRectangleLines, 
+        "(image-draw-rectangle-lines dst rec thick color)\n\n"
+        "Draw rectangle lines within an image"
+    },
+    {"image-draw-text", cfun_ImageDrawText, 
+        "(image-draw-text dst text pos-x pos-y font-size color)\n\n"
+        "Draw text (using default font) within an image (destination)"
+    },
+    {"image-draw-text-ex", cfun_ImageDrawTextEx, 
+        "(image-draw-text-ex dst font text [pos-x pos-y] font-size spacing tint)\n\n"
+        "Draw text (custom sprite font) within an image (destination)"
+    },
+    {"image-flip-vertical", cfun_ImageFlipVertical, 
+        "(image-flip-vertical image)\n\n"
+        "Flip image vertically"
+    },
+    {"image-flip-horizontal", cfun_ImageFlipHorizontal, 
+        "(image-flip-horizontal image)\n\n"
+        "Flip image horizontally"
+    },
+    {"image-rotate-cw", cfun_ImageRotateCW, 
+        "(image-rotate-cw image)\n\n"
+        "Rotate image clockwise 90deg"
+    },
+    {"image-rotate-ccw", cfun_ImageRotateCCW, 
+        "(image-rotate-ccw image)\n\n"
+        "Rotate image counter-clockwise 90deg"
+    },
+    {"image-color-tint", cfun_ImageColorTint, 
+        "(image-color-tint image color)\n\n"
+        "Modify image color: tint"
+    },
+    {"image-color-invert", cfun_ImageColorInvert, 
+        "(image-color-invert image)\n\n"
+        "Modify image color: invert"
+    },
+    {"image-color-grayscale", cfun_ImageColorGrayscale, 
+        "(image-color-grayscale image)\n\n"
+        "Modify image color: grayscale"
+    },
+    {"image-color-brightness", cfun_ImageColorBrightness, 
+        "(image-color-brightness image brightness)\n\n"
+        "Modify image color: brightness (-255 to 255)"
+    },
+    {"image-color-contrast", cfun_ImageColorContrast, 
+        "(image-color-contrast image contrast)\n\n"
+        "Modify image color: contrast (-100 to 100)"
+    },
+    {"image-color-replace", cfun_ImageColorReplace, 
+        "(image-color-replace image color replace)\n\n"
+        "Modify image color: replace color"
+    },
+    {"draw-texture", cfun_DrawTexture, 
+        "(draw-texture texture pos-x pos-y tint)\n\n"
+        "Draw a Texture2D"
+    },
+    {"draw-texture-v", cfun_DrawTextureV, 
+        "(draw-texture-v texture [pos-x pos-y] tint)\n\n"
+        "Draw a Texture2D with position defined as Vector2"
+    },
+    {"draw-texture-ex", cfun_DrawTextureEx, 
+        "(draw-texture-ex texture [pos-x pos-y] rotation scale tint)\n\n"
+        "Draw a Texture2D with extended parameters"
+    },
+    {"draw-texture-pro", cfun_DrawTexturePro, 
+        "(draw-texture-pro texture source dest origin rotation tint)\n\n"
+        "Draw a part of a texture defined by a rectangle with 'pro' parameters"
+    },
+    {"draw-texture-quad", cfun_DrawTextureQuad, 
+        "(draw-texture-quad texture [t1 t2] [off-x off-y] quad tint)\n\n"
+        "Draw texture quad with tiling and offset parameters"
+    },
+    {"draw-texture-rec", cfun_DrawTextureRec, 
+        "(draw-texture-rec texture source position tint)\n\n"
+        "Draw a part of a texture defined by a rectangle"
+    },
+    {"gen-image-color", cfun_GenImageColor, 
+        "(gen-image-color width height color)\n\n"
+        "Generate image: plain color"
+    },
+    {"gen-image-gradient-v", cfun_GenImageGradientV, 
+        "(gen-image-gradient-v width height top bottom)\n\n"
+        "Generate image: vertical gradient"
+    },
+    {"gen-image-gradient-h", cfun_GenImageGradientH, 
+        "(gen-image-gradient-h width height left right)\n\n"
+        "Generate image: horizontal gradient"
+    },
+    {"gen-image-gradient-radial", cfun_GenImageGradientRadial, 
+        "(gen-image-gradient-radial width height density inner outer)\n\n"
+        "Generate image: radial gradient"
+    },
+    {"gen-image-checked", cfun_GenImageChecked, 
+        "(gen-image-checked width height checks-x checks-y color1 color2)\n\n"
+        "Generate image: checked"
+    },
+    {"gen-image-white-noise", cfun_GenImageWhiteNoise, 
+        "(gen-image-white-noise width height factor)\n\n"
+        "Generate image: white noise"
+    },
+    {"gen-image-cellular", cfun_GenImageCellular, 
+        "(gen-image-cellular width height tile-size)\n\n"
+        "Generate image: cellular algorithm. Bigger tileSize means bigger cells"
+    },
+    {"gen-texture-mipmaps", cfun_GenTextureMipmaps, 
+        "(gen-texture-mipmaps texture)\n\n"
+        "Generate GPU mipmaps for a texture"
+    },
+    {"set-texture-filter", cfun_SetTextureFilter, 
+        "(set-texture-filter texture filter)\n\n"
+        "Set texture scaling filter mode"
+    },
+    {"set-texture-wrap", cfun_SetTextureWrap, 
+        "(set-texture-wrap texture wrap)\n\n"
+        "Set texture wrapping mode"
+    },
     {NULL, NULL, NULL}
 };

--- a/src/shapes.h
+++ b/src/shapes.h
@@ -443,45 +443,166 @@ static Janet cfun_GetCollisionRec(int32_t argc, Janet *argv) {
 }
 
 static JanetReg shapes_cfuns[] = {
-    {"draw-pixel", cfun_DrawPixel, NULL},
-    {"draw-pixel-v", cfun_DrawPixelV, NULL},
-    {"draw-line", cfun_DrawLine, NULL},
-    {"draw-line-v", cfun_DrawLineV, NULL},
-    {"draw-line-ex", cfun_DrawLineEx, NULL},
-    {"draw-line-bezier", cfun_DrawLineBezier, NULL},
-    {"draw-line-strip", cfun_DrawLineStrip, NULL},
-    {"draw-circle", cfun_DrawCircle, NULL},
-    {"draw-circle-sector", cfun_DrawCircleSector, NULL},
-    {"draw-circle-sector-lines", cfun_DrawCircleSectorLines, NULL},
-    {"draw-circle-v", cfun_DrawCircleV, NULL},
-    {"draw-circle-gradient", cfun_DrawCircleGradient, NULL},
-    {"draw-circle-lines", cfun_DrawCircleLines, NULL},
-    {"draw-ring", cfun_DrawRing, NULL},
-    {"draw-ring-lines", cfun_DrawRingLines, NULL},
-    {"draw-rectangle", cfun_DrawRectangle, NULL},
-    {"draw-rectangle-v", cfun_DrawRectangleV, NULL},
-    {"draw-rectangle-rec", cfun_DrawRectangleRec, NULL},
-    {"draw-rectangle-pro", cfun_DrawRectanglePro, NULL},
-    {"draw-rectangle-gradient-v", cfun_DrawRectangleGradientV, NULL},
-    {"draw-rectangle-gradient-h", cfun_DrawRectangleGradientH, NULL},
-    {"draw-rectangle-gradient-ex", cfun_DrawRectangleGradientEx, NULL},
-    {"draw-rectangle-lines", cfun_DrawRectangleLines, NULL},
-    {"draw-rectangle-lines-ex", cfun_DrawRectangleLinesEx, NULL},
-    {"draw-rectangle-rounded", cfun_DrawRectangleRounded, NULL},
-    {"draw-rectangle-rounded-lines", cfun_DrawRectangleRoundedLines, NULL},
-    {"draw-triangle", cfun_DrawTriangle, NULL},
-    {"draw-triangle-lines", cfun_DrawTriangleLines, NULL},
-    {"draw-triangle-fan", cfun_DrawTriangleFan, NULL},
-    {"draw-triangle-strip", cfun_DrawTriangleStrip, NULL},
-    {"draw-poly", cfun_DrawPoly, NULL},
-    {"check-collision-recs", cfun_CheckCollisionRecs, NULL},
-    {"check-collision-circles", cfun_CheckCollisionCircles, "Check collision between two circles"},
-    {"check-collision-circle-rec", cfun_CheckCollisionCircleRec, "Check collision between circle and rectangle"},
-    {"check-collision-point-rec", cfun_CheckCollisionPointRec, "Check if point is inside rectangle"},
-    {"check-collision-point-circle", cfun_CheckCollisionPointCircle, "Check if point is inside circle"},
-    {"check-collision-point-triangle", cfun_CheckCollisionPointTriangle, "Check if point is inside a triangle"},
-    {"check-collision-lines", cfun_CheckCollisionLines, "Check the collision between two lines defined by two points each, returns collision point"},
-    {"check-collision-point-line", cfun_CheckCollisionPointLine, "Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]"},
-    {"get-collision-rec", cfun_GetCollisionRec, "Get collision rectangle for two rectangles collision"},
+    {"draw-pixel", cfun_DrawPixel, 
+        "(draw-pixel pos-x pos-y color)\n\n"
+        "Draw a pixel"
+    },
+    {"draw-pixel-v", cfun_DrawPixelV, 
+        "(draw-pixel-v [pos-x pos-y] color)\n\n"
+        "Draw a pixel (Vector version)"
+    },
+    {"draw-line", cfun_DrawLine, 
+        "(draw-line start-pos-x start-pos-y end-pos-x end-pos-y color)\n\n"
+        "Draw a line"
+    },
+    {"draw-line-v", cfun_DrawLineV, 
+        "(draw-line-v [start-pos-x start-pos-y] [end-pos-x end-pos-y] color)\n\n"
+        "Draw a line (Vector version)"
+    },
+    {"draw-line-ex", cfun_DrawLineEx, 
+        "(draw-line-ex [start-pos-x start-pos-y] [end-pos-x end-pos-y] thick color)\n\n"
+        "Draw a line defining thickness"
+    },
+    {"draw-line-bezier", cfun_DrawLineBezier, 
+        "(draw-line-bezier [start-pos-x start-pos-y] [end-pos-x end-pos-y] thick color)\n\n"
+        "Draw a line using cubic-bezier curves in-out"
+    },
+    {"draw-line-strip", cfun_DrawLineStrip, 
+        "(draw-line-strip [a b] points-count color)\n\n"
+        "Draw lines sequence"
+    },
+    {"draw-circle", cfun_DrawCircle, 
+        "(draw-circle center-x center-y radius color)\n\n"
+        "Draw a color-filled circle"
+    },
+    {"draw-circle-sector", cfun_DrawCircleSector, 
+        "(draw-circle-sector [pos-x pos-y] radius start-angle end-angle segments color)\n\n"
+        "Draw a piece of a circle"
+    },
+    {"draw-circle-sector-lines", cfun_DrawCircleSectorLines, 
+        "(draw-circle-sector-lines [pos-x pos-y] radius start-angle end-angle segments color)\n\n"
+        "Draw circle sector outline"
+    },
+    {"draw-circle-v", cfun_DrawCircleV, 
+        "(draw-circle-v [pos-x pos-y] radius color)\n\n"
+        "Draw a color-filled circle (Vector version)"
+    },
+    {"draw-circle-gradient", cfun_DrawCircleGradient, 
+        "(draw-circle-gradient center-x center-y radius color-1 color-2)\n\n"
+        "Draw a gradient-filled circle"
+    },
+    {"draw-circle-lines", cfun_DrawCircleLines, 
+        "(draw-circle-lines center-x center-y radius color)\n\n"
+        "Draw circle outline"
+    },
+    {"draw-ring", cfun_DrawRing, 
+        "(draw-ring [pos-x pos-y] inner-radius outer-radius start-angle end-angle segments color)\n\n"
+        "Draw ring"
+    },
+    {"draw-ring-lines", cfun_DrawRingLines, 
+        "(draw-ring-lines [pos-x pos-y] inner-radius outer-radius start-angle end-angle segments color)\n\n"
+        "Draw ring outline"
+    },
+    {"draw-rectangle", cfun_DrawRectangle, 
+        "(draw-rectangle pos-x pos-y width height color)\n\n"
+        "Draw a color-filled rectangle"
+    },
+    {"draw-rectangle-v", cfun_DrawRectangleV, 
+        "(draw-rectangle-v [pos-x pos-y] [width height] color)\n\n"
+        "Draw a color-filled rectangle (Vector version)"
+    },
+    {"draw-rectangle-rec", cfun_DrawRectangleRec, 
+        "(draw-rectangle-rec rec color)\n\n"
+        "Draw a color-filled rectangle"
+    },
+    {"draw-rectangle-pro", cfun_DrawRectanglePro, 
+        "(draw-rectangle-pro rec origin rotation color)\n\n"
+        "Draw a color-filled rectangle with pro parameters"
+    },
+    {"draw-rectangle-gradient-v", cfun_DrawRectangleGradientV, 
+        "(draw-rectangle-gradient-v pos-x pos-y width height color-1 color-2)\n\n"
+        "Draw a vertical-gradient-filled rectangle"
+    },
+    {"draw-rectangle-gradient-h", cfun_DrawRectangleGradientH, 
+        "(draw-rectangle-gradient-h pos-x pos-y width height color-1 color-2)\n\n"
+        "Draw a horizontal-gradient-filled rectangle"
+    },
+    {"draw-rectangle-gradient-ex", cfun_DrawRectangleGradientEx, 
+        "(draw-rectangle-gradient-ex rec color-1 color-2 color-3 color-4)\n\n"
+        "Draw a gradient-filled rectangle with custom vertex colors"
+    },
+    {"draw-rectangle-lines", cfun_DrawRectangleLines, 
+        "(draw-rectangle-lines pos-x pos-y width height color)\n\n"
+        "Draw rectangle outline"
+    },
+    {"draw-rectangle-lines-ex", cfun_DrawRectangleLinesEx, 
+        "(draw-rectangle-lines-ex rec line-thick color)\n\n"
+        "Draw rectangle outline with extended parameters"
+    },
+    {"draw-rectangle-rounded", cfun_DrawRectangleRounded, 
+        "(draw-rectangle-rounded rec roundness segments color)\n\n"
+        "Draw rectangle with rounded edges"
+    },
+    {"draw-rectangle-rounded-lines", cfun_DrawRectangleRoundedLines, 
+        "(draw-rectangle-rounded-lines rec roundness segments line-thick color)\n\n"
+        "Draw rectangle with rounded edges outline"
+    },
+    {"draw-triangle", cfun_DrawTriangle, 
+        "(draw-triangle [x1 y1] [x2 y2] [x3 y3] color)\n\n"
+        "Draw a color-filled triangle (vertex in counter-clockwise order!)"
+    },
+    {"draw-triangle-lines", cfun_DrawTriangleLines, 
+        "(draw-triangle-lines [x1 y1] [x2 y2] [x3 y3] color)\n\n"
+        "Draw triangle outline (vertex in counter-clockwise order!)"
+    },
+    {"draw-triangle-fan", cfun_DrawTriangleFan, 
+        "(draw-triangle-fan [x y] points-count color)\n\n"
+        "Draw a triangle fan defined by points (first vertex is the center)"
+    },
+    {"draw-triangle-strip", cfun_DrawTriangleStrip, 
+        "(draw-triangle-strip [x y] points-count color)\n\n"
+        "Draw a triangle strip defined by points"
+    },
+    {"draw-poly", cfun_DrawPoly, 
+        "(draw-poly [pos-x pos-y] sides radius rotation color)\n\n"
+        "Draw a regular polygon (Vector version)"
+    },
+    {"check-collision-recs", cfun_CheckCollisionRecs, 
+        "(check-collision-recs rec-1 rec-2)\n\n"
+        "Check collision between two rectangles"
+    },
+    {"check-collision-circles", cfun_CheckCollisionCircles, 
+        "(check-collision-circles [x1 y1] r1 [x2 y2] r2)\n\n"
+        "Check collision between two circles"
+    },
+    {"check-collision-circle-rec", cfun_CheckCollisionCircleRec, 
+        "(check-collision-circle-rec [x y] radius rec)\n\n"
+        "Check collision between circle and rectangle"
+    },
+    {"check-collision-point-rec", cfun_CheckCollisionPointRec, 
+        "(check-collision-point-rec [x y] rec)\n\n"
+        "Check if point is inside rectangle"
+    },
+    {"check-collision-point-circle", cfun_CheckCollisionPointCircle, 
+        "(check-collision-point-circle [px py] [cx cy] r)\n\n"
+        "Check if point is inside circle"
+    },
+    {"check-collision-point-triangle", cfun_CheckCollisionPointTriangle, 
+        "(check-collision-point-triangle [px py] [x1 y1] [x2 y2] [x3 y3])\n\n"
+        "Check if point is inside a triangle"
+    },
+    {"check-collision-lines", cfun_CheckCollisionLines, 
+        "(check-collision-lines [start-x1 start-y1] [end-x1 end-y1] [start-x2 start-y2] [end-x2 end-y2] [ret-x ret-y])\n\n"
+        "Check the collision between two lines defined by two points each, returns collision point"
+    },
+    {"check-collision-point-line", cfun_CheckCollisionPointLine, 
+        "(check-collision-point-line [px py] [start-x start-y] [end-x end-y] threshold)\n\n"
+        "Check if point belongs to line created between two points [p1] "
+        "and [p2] with defined margin in pixels [threshold]"
+    },
+    {"get-collision-rec", cfun_GetCollisionRec, 
+        "(get-collision-rec rec1 rec2)\n\n"
+        "Get collision rectangle for two rectangles collision"
+    },
     {NULL, NULL, NULL}
 };

--- a/src/text.h
+++ b/src/text.h
@@ -116,16 +116,49 @@ static Janet cfun_GetFontTexture(int32_t argc, Janet *argv) {
 }
 
 static JanetReg text_cfuns[] = {
-    {"get-font-default", cfun_GetFontDefault, "(get-font-default)\n\n" "Get the default Font"},
-    {"load-font", cfun_LoadFont, "(load-font file-name)\n\n" "Load font from file into GPU memory (VRAM)"},
-    {"load-font-ex", cfun_LoadFontEx, "(load-font-ex file-name font-size font-chars glyph-count)\n\n" "Load font from file with extended parameters"},
-    {"unload-font", cfun_UnloadFont, "(unload-font font)\n\n" "Unload Font from GPU memory (VRAM)"},
-    {"draw-fps", cfun_DrawFPS, "(draw-fps pos-x pos-y)\n\n" "Draw current FPS"},
-    {"draw-text", cfun_DrawText, "(draw-text text pos-x pos-y font-size color)\n\n" "Draw text (using default font)"},
-    {"draw-text-ex", cfun_DrawTextEx, "(draw-text-ex font text [pos-x pos-y] font-size spacing tint)\n\n" "Draw text using font and additional parameters"},
-    {"measure-text", cfun_MeasureText, "(measure-text text font-size)\n\n" "Measure string width for default font"},
-    {"measure-text-ex", cfun_MeasureTextEx, "(measure-text-ex font text font-size spacing)\n\n" "Measure string size for Font"},
-    {"get-glyph-index", cfun_GetGlyphIndex, "(get-glyph-index font codepoint)\n\n" "Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found"},
-    {"get-font-texture", cfun_GetFontTexture, "(get-font-texture font)\n\n" ""},
+    {"get-font-default", cfun_GetFontDefault, 
+        "(get-font-default)\n\n" 
+        "Get the default Font"
+    },
+    {"load-font", cfun_LoadFont, 
+        "(load-font file-name)\n\n" 
+        "Load font from file into GPU memory (VRAM)"
+    },
+    {"load-font-ex", cfun_LoadFontEx, 
+        "(load-font-ex file-name font-size font-chars glyph-count)\n\n" 
+        "Load font from file with extended parameters"
+    },
+    {"unload-font", cfun_UnloadFont, 
+        "(unload-font font)\n\n" 
+        "Unload Font from GPU memory (VRAM)"
+    },
+    {"draw-fps", cfun_DrawFPS, 
+        "(draw-fps pos-x pos-y)\n\n" 
+        "Draw current FPS"
+    },
+    {"draw-text", cfun_DrawText, 
+        "(draw-text text pos-x pos-y font-size color)\n\n" 
+        "Draw text (using default font)"
+    },
+    {"draw-text-ex", cfun_DrawTextEx, 
+        "(draw-text-ex font text [pos-x pos-y] font-size spacing tint)\n\n" 
+        "Draw text using font and additional parameters"
+    },
+    {"measure-text", cfun_MeasureText, 
+        "(measure-text text font-size)\n\n" 
+        "Measure string width for default font"
+    },
+    {"measure-text-ex", cfun_MeasureTextEx, 
+        "(measure-text-ex font text font-size spacing)\n\n" 
+        "Measure string size for Font"
+    },
+    {"get-glyph-index", cfun_GetGlyphIndex, 
+        "(get-glyph-index font codepoint)\n\n" 
+        "Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found"
+    },
+    {"get-font-texture", cfun_GetFontTexture, 
+        "(get-font-texture font)\n\n" 
+        ""
+    },
     {NULL, NULL, NULL}
 };

--- a/src/text.h
+++ b/src/text.h
@@ -116,16 +116,16 @@ static Janet cfun_GetFontTexture(int32_t argc, Janet *argv) {
 }
 
 static JanetReg text_cfuns[] = {
-    {"get-font-default", cfun_GetFontDefault, NULL},
-    {"load-font", cfun_LoadFont, NULL},
-    {"load-font-ex", cfun_LoadFontEx, NULL},
-    {"unload-font", cfun_UnloadFont, NULL},
-    {"draw-fps", cfun_DrawFPS, NULL},
-    {"draw-text", cfun_DrawText, NULL},
-    {"draw-text-ex", cfun_DrawTextEx, NULL},
-    {"measure-text", cfun_MeasureText, NULL},
-    {"measure-text-ex", cfun_MeasureTextEx, NULL},
-    {"get-glyph-index", cfun_GetGlyphIndex, NULL},
-    {"get-font-texture", cfun_GetFontTexture, NULL},
+    {"get-font-default", cfun_GetFontDefault, "(get-font-default)\n\n" "Get the default Font"},
+    {"load-font", cfun_LoadFont, "(load-font file-name)\n\n" "Load font from file into GPU memory (VRAM)"},
+    {"load-font-ex", cfun_LoadFontEx, "(load-font-ex file-name font-size font-chars glyph-count)\n\n" "Load font from file with extended parameters"},
+    {"unload-font", cfun_UnloadFont, "(unload-font font)\n\n" "Unload Font from GPU memory (VRAM)"},
+    {"draw-fps", cfun_DrawFPS, "(draw-fps pos-x pos-y)\n\n" "Draw current FPS"},
+    {"draw-text", cfun_DrawText, "(draw-text text pos-x pos-y font-size color)\n\n" "Draw text (using default font)"},
+    {"draw-text-ex", cfun_DrawTextEx, "(draw-text-ex font text [pos-x pos-y] font-size spacing tint)\n\n" "Draw text using font and additional parameters"},
+    {"measure-text", cfun_MeasureText, "(measure-text text font-size)\n\n" "Measure string width for default font"},
+    {"measure-text-ex", cfun_MeasureTextEx, "(measure-text-ex font text font-size spacing)\n\n" "Measure string size for Font"},
+    {"get-glyph-index", cfun_GetGlyphIndex, "(get-glyph-index font codepoint)\n\n" "Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found"},
+    {"get-font-texture", cfun_GetFontTexture, "(get-font-texture font)\n\n" ""},
     {NULL, NULL, NULL}
 };


### PR DESCRIPTION
Added function signatures and docstrings based on raylib cheat sheet: https://www.raylib.com/cheatsheet/cheatsheet.html

Now `(doc init-window)` (and other jaylib functions) returns helpful info when invoked in the REPL.

All tests still pass.