### PR TITLE
Update project.janet to fix building on macos

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -26,7 +26,7 @@
 
   :cflags [;default-cflags ;cflags]
 
-  :defines {"PLATFORM_DESKTOP" true "_POSIX_C_SOURCE" "200809L"}
+  :defines {"PLATFORM_DESKTOP" true "_POSIX_C_SOURCE" "200809L" "_DARWIN_C_SOURCE" (if (= o :macos) "1" nil)}
 
   :source ["src/main.c"
 


### PR DESCRIPTION
Buliding on macos I got same errors as: https://github.com/axel-download-accelerator/axel/issues/136

According to the issue, you need a flag `_DARWIN_C_SOURCE` when `_POSIX_C_SOURCE` is set.
Setting that flag when OS is macos works for me, and shouldn't interfere with other OSes.