### PR TITLE
Basic shader bindings

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -372,16 +372,16 @@
 
 // Shader loading/unloading functions
 [ ] char *LoadText(const char *fileName)
-[ ] Shader LoadShader(const char *vsFileName, const char *fsFileName)
+[x] Shader LoadShader(const char *vsFileName, const char *fsFileName)
 [ ] Shader LoadShaderCode(char *vsCode, char *fsCode)
-[ ] void UnloadShader(Shader shader)
+[x] void UnloadShader(Shader shader)
 
 [ ] Shader GetShaderDefault(void)
 [ ] Texture2D GetTextureDefault(void)
 
 // Shader configuration functions
-[ ] int GetShaderLocation(Shader shader, const char *uniformName)
-[ ] void SetShaderValue(Shader shader, int uniformLoc, const void *value, int uniformType)
+[x] int GetShaderLocation(Shader shader, const char *uniformName)
+[x] void SetShaderValue(Shader shader, int uniformLoc, const void *value, int uniformType)
 [ ] void SetShaderValueV(Shader shader, int uniformLoc, const void *value, int uniformType, int count)
 [ ] void SetShaderValueMatrix(Shader shader, int uniformLoc, Matrix mat)
 [ ] void SetShaderValueTexture(Shader shader, int uniformLoc, Texture2D texture)
@@ -390,8 +390,8 @@
 [ ] Matrix GetMatrixModelview()
 
 // Shading begin/end functions
-[ ] void BeginShaderMode(Shader shader)
-[ ] void EndShaderMode(void)
+[x] void BeginShaderMode(Shader shader)
+[x] void EndShaderMode(void)
 [ ] void BeginBlendMode(int mode)
 [ ] void EndBlendMode(void)
 [ ] void BeginScissorMode(int x, int y, int width, int height)

--- a/project.janet
+++ b/project.janet
@@ -48,7 +48,8 @@
             "src/image.h"
             "src/shapes.h"
             "src/3d.h"
-            "src/rlgl.h"]
+            "src/rlgl.h"
+            "src/shader.h"]
 
   :lflags [;default-lflags ;lflags])
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "image.h"
 #include "3d.h"
 #include "rlgl.h"
+#include "shader.h"
 
 JANET_MODULE_ENTRY(JanetTable *env) {
     janet_cfuns(env, "jaylib", core_cfuns);
@@ -22,4 +23,5 @@ JANET_MODULE_ENTRY(JanetTable *env) {
     janet_cfuns(env, "jaylib", image_cfuns);
     janet_cfuns(env, "jaylib", threed_cfuns);
     janet_cfuns(env, "jaylib", rlgl_cfuns);
+    janet_cfuns(env, "jaylib", shader_cfuns);
 }

--- a/src/shader.h
+++ b/src/shader.h
@@ -1,0 +1,108 @@
+static Janet cfun_LoadShader(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 2);
+    const char *vertexShaderFileName;
+    const char *fragmentShaderFileName;
+    if (janet_checktype(argv[0], JANET_NIL)) {
+        vertexShaderFileName = NULL;
+    } else {
+        vertexShaderFileName = janet_getcstring(argv, 0);
+    }
+    if (janet_checktype(argv[1], JANET_NIL)) {
+        fragmentShaderFileName = NULL;
+    } else {
+        fragmentShaderFileName = janet_getcstring(argv, 1);
+    }
+    Shader *shader = janet_abstract(&AT_Shader, sizeof(Shader));
+    *shader = LoadShader(vertexShaderFileName, fragmentShaderFileName);
+    return janet_wrap_abstract(shader);
+}
+
+static Janet cfun_UnloadShader(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    Shader *shader = jaylib_getshader(argv, 0);
+    UnloadShader(*shader);
+    return janet_wrap_nil();
+}
+
+static Janet cfun_BeginShaderMode(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    Shader *shader = jaylib_getshader(argv, 0);
+    BeginShaderMode(*shader);
+    return janet_wrap_nil();
+}
+
+static Janet cfun_EndShaderMode(int32_t argc, Janet *argv) {
+    (void) argv;
+    janet_fixarity(argc, 0);
+    EndShaderMode();
+    return janet_wrap_nil();
+}
+
+static Janet cfun_GetShaderLocation(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 2);
+    Shader *shader = jaylib_getshader(argv, 0);
+    const char *uniformName = janet_getcstring(argv, 1);
+    int locIndex = GetShaderLocation(*shader, uniformName);
+    return janet_wrap_integer(locIndex);
+}
+
+static Janet cfun_SetShaderValue(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 4);
+    Shader *shader = jaylib_getshader(argv, 0);
+    int locIndex = janet_getinteger(argv, 1);
+    int uniformType = jaylib_getuniformtype(argv, 3);
+    switch (uniformType) {
+        case SHADER_UNIFORM_FLOAT:
+            float valueFloat = (float) janet_getnumber(argv, 2);
+            SetShaderValue(*shader, locIndex, (const void*) &valueFloat, uniformType);
+            break;
+        case SHADER_UNIFORM_INT:
+            int valueInt = janet_getinteger(argv, 2);
+            SetShaderValue(*shader, locIndex, (const void*) &valueInt, uniformType);
+            break;
+        case SHADER_UNIFORM_VEC2:
+            Vector2 valueVec2 = jaylib_getvec2(argv, 2);
+            SetShaderValue(*shader, locIndex, (const void*) &valueVec2, uniformType);
+            break;
+        case SHADER_UNIFORM_VEC3:
+            Vector3 valueVec3 = jaylib_getvec3(argv, 2);
+            SetShaderValue(*shader, locIndex, (const void*) &valueVec3, uniformType);
+            break;
+        case SHADER_UNIFORM_VEC4:
+            Vector4 valueVec4 = jaylib_getvec4(argv, 2);
+            SetShaderValue(*shader, locIndex, (const void*) &valueVec4, uniformType);
+            break;
+        default:
+            janet_panicf("unknown uniform type %d", uniformType);
+            break;
+    }
+    return janet_wrap_nil();
+}
+
+static JanetReg shader_cfuns[] = {
+    {"load-shader", cfun_LoadShader,
+        "(loader-shader vertex-shader fragment-shader)\n\n"
+        "Load shader from files and bind default locations"
+    },
+    {"unload-shader", cfun_UnloadShader,
+        "(unloader-shader shader)\n\n"
+        "Unload shader from GPU memory (VRAM)"
+    },
+    {"begin-shader-mode", cfun_BeginShaderMode,
+        "(begin-shader-mode shader)\n\n"
+        "Begin custom shader drawing"
+    },
+    {"end-shader-mode", cfun_EndShaderMode,
+        "(end-shader-mode)\n\n"
+        "End custom shader drawing (use default shader)"
+    },
+    {"get-shader-location", cfun_GetShaderLocation,
+        "(set-shader-location shader uniform-name)\n\n"
+        "Get shader uniform location"
+    },
+    {"set-shader-value", cfun_SetShaderValue,
+        "(set-shader-value shader loc-index value uniform-type)\n\n"
+        "Set shader uniform value"
+    },
+    {NULL, NULL, NULL}
+};

--- a/src/types.h
+++ b/src/types.h
@@ -188,6 +188,14 @@ static const KeyDef mouse_defs[] = {
     {"right", MOUSE_RIGHT_BUTTON}
 };
 
+static const KeyDef uniform_type_defs[] = {
+    {"float", SHADER_UNIFORM_FLOAT},
+    {"int", SHADER_UNIFORM_INT},
+    {"vec2", SHADER_UNIFORM_VEC2},
+    {"vec3", SHADER_UNIFORM_VEC3},
+    {"vec4", SHADER_UNIFORM_VEC4}
+};
+
 static int jaylib_castdef(const Janet *argv, int32_t n, const KeyDef *defs, int count) {
     if (janet_checkint(argv[n])) {
         return janet_unwrap_integer(argv[n]);
@@ -224,6 +232,10 @@ static int jaylib_getaxis(const Janet *argv, int32_t n) {
 
 static int jaylib_getmouse(const Janet *argv, int32_t n) {
     return jaylib_castdef(argv, n, mouse_defs, sizeof(mouse_defs) / sizeof(KeyDef));
+}
+
+static int jaylib_getuniformtype(const Janet *argv, int32_t n) {
+    return jaylib_castdef(argv, n, uniform_type_defs, sizeof(uniform_type_defs) / sizeof(KeyDef));
 }
 
 struct named_color {
@@ -332,6 +344,16 @@ static Vector3 jaylib_getvec3(const Janet *argv, int32_t n) {
     };
 }
 
+static Vector4 jaylib_getvec4(const Janet *argv, int32_t n) {
+    JanetView idx = janet_getindexed(argv, n);
+    return (Vector4) {
+        idx_getfloat(idx, 0),
+        idx_getfloat(idx, 1),
+        idx_getfloat(idx, 2),
+        idx_getfloat(idx, 3)
+    };
+}
+
 static Rectangle jaylib_getrect(const Janet *argv, int32_t n) {
     JanetView idx = janet_getindexed(argv, n);
     return (Rectangle) {
@@ -412,6 +434,14 @@ static TextureCubemap *jaylib_gettexturecubemap(const Janet *argv, int32_t n) {
     return ((TextureCubemap *)janet_getabstract(argv, n, &AT_TextureCubemap));
 }
 */
+static const JanetAbstractType AT_Shader = {
+    "jaylib/shader",
+    JANET_ATEND_NAME
+};
+
+static Shader *jaylib_getshader(const Janet *argv, int32_t n) {
+    return ((Shader *)janet_getabstract(argv, n, &AT_Shader));
+};
 
 static const JanetAbstractType AT_Texture2D = {
     "jaylib/texture2d",

--- a/test/test6.fs
+++ b/test/test6.fs
@@ -1,0 +1,35 @@
+#version 330
+
+// Input vertex attributes (from vertex shader)
+in vec2 fragTexCoord;
+in vec4 fragColor;
+
+// Input uniform values
+uniform sampler2D texture0;
+uniform vec4 colDiffuse;
+uniform float time;
+uniform vec2 freq;
+uniform vec4 params;
+uniform int width;
+uniform int height;
+
+// Output fragment color
+out vec4 finalColor;
+
+void main() {
+    vec2 freq = freq.xy;
+    vec2 amp = params.xy;
+    vec2 speed = params.zw;
+
+    float pixelWidth = 1.0 / width;
+    float pixelHeight = 1.0 / height;
+    float aspect = pixelHeight / pixelWidth;
+
+    vec2 p = fragTexCoord;
+    p.x += cos(fragTexCoord.y * freq.x / ( pixelWidth * 1000.0) + (time * speed.x)) * amp.x * pixelWidth;
+    p.y += sin(fragTexCoord.x * freq.y * aspect / ( pixelHeight * 1000.0) + (time * speed.y)) * amp.y * pixelHeight;
+
+    vec4 texelColor = texture(texture0, fragTexCoord);
+
+    finalColor = texture(texture0, p)*colDiffuse*fragColor;
+}

--- a/test/test6.janet
+++ b/test/test6.janet
@@ -1,0 +1,54 @@
+(use ../build/jaylib)
+
+(set-config-flags :msaa-4x-hint)
+
+(init-window 800 600 "Test Game")
+(set-target-fps 60)
+
+(def lenna (load-image-1 "test/lenna.png"))
+(image-dither lenna 4 4 4 4)
+(def lenna-t (load-texture-from-image lenna))
+(gen-texture-mipmaps lenna-t)
+
+(def shader (load-shader "test/test6.vs" "test/test6.fs"))
+(def time-loc (get-shader-location shader "time"))
+(def width-loc (get-shader-location shader "width"))
+(def height-loc (get-shader-location shader "height"))
+(def freq-loc (get-shader-location shader "freq"))
+(def params-loc (get-shader-location shader "params"))
+
+(set-shader-value shader width-loc (get-screen-width) :int)
+(set-shader-value shader height-loc (get-screen-height) :int)
+(set-shader-value shader freq-loc [25 25] :vec2)
+(set-shader-value shader params-loc [5 5 4 4] :vec4)
+
+(def c (camera-3d :target [0 0 0]
+                  :up [0 1 0]
+                  :fovy 35
+                  :type :perspective
+                  :position [2 4 6]))
+(set-camera-mode c :orbital)
+
+(var time 0)
+
+(while (not (window-should-close))
+  (set time (+ time (get-frame-time)))
+  (set-shader-value shader time-loc time :float)
+  (update-camera c)
+
+  (begin-drawing)
+  (draw-fps 10 10)
+  (clear-background :black)
+
+  (begin-mode-3d c)
+  (begin-shader-mode shader)
+
+  (draw-cube-texture lenna-t [0 0 0] 2 2 2 :red)
+
+  (end-shader-mode)
+  (end-mode-3d)
+
+  (end-drawing))
+
+(unload-shader shader)
+(close-window)

--- a/test/test6.vs
+++ b/test/test6.vs
@@ -1,0 +1,23 @@
+#version 330
+
+// Input vertex attributes
+in vec3 vertexPosition;
+in vec2 vertexTexCoord;
+in vec3 vertexNormal;
+in vec4 vertexColor;
+
+// Input uniform values
+uniform mat4 mvp;
+
+// Output vertex attributes (to fragment shader)
+out vec2 fragTexCoord;
+out vec4 fragColor;
+
+void main() {
+    // Send vertex attributes to fragment shader
+    fragTexCoord = vertexTexCoord * -1;
+    fragColor = vec4(vertexPosition, 1);
+
+    // Calculate final vertex position
+    gl_Position = mvp*vec4(vertexPosition, 1);
+}


### PR DESCRIPTION
Bindings to load shaders and set common uniform types.

Took some inspiration from [this fork](https://github.com/ianthehenry/jaylib), though with a different approach to setting shader values (`(set-shader-value shader loc-index [1 2] :vec2)` vs `(set-shader-value-vec2 shader uniform-name [1 2])`). Not sure which implementation is considered more idiomatic?