### PR TITLE
Add LoadMusicStreamFromMemory function

### DIFF
--- a/src/audio.h
+++ b/src/audio.h
@@ -178,6 +178,16 @@ static Janet cfun_LoadMusicStream(int32_t argc, Janet *argv) {
     return janet_wrap_abstract(music);
 }
 
+static Janet cfun_LoadMusicStreamFromMemory(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 3);
+    const char *fileType = janet_getcstring(argv, 0);
+    const unsigned char *data = jaylib_getunsignedcstring(argv, 1);
+    int dataSize = janet_getinteger(argv, 2);
+    Music *music = janet_abstract(&AT_Music, sizeof(Music));
+    *music = LoadMusicStreamFromMemory(fileType, data, dataSize);
+    return janet_wrap_abstract(music);
+}
+
 static Janet cfun_IsMusicReady(int32_t argc, Janet *argv) {
     janet_fixarity(argc, 1);
     Music music = *jaylib_getmusic(argv, 0);
@@ -445,6 +455,10 @@ static JanetReg audio_cfuns[] = {
     {"load-music-stream", cfun_LoadMusicStream, 
         "(load-music-stream file-name)\n\n"
         "Load music stream from file"
+    },
+    {"load-music-stream-from-memory", cfun_LoadMusicStreamFromMemory, 
+        "(load-music-stream-from-memory file-type data data-size)\n\n"
+        "Load music stream from data"
     },
     {"music-ready?", cfun_IsMusicReady,
         "(music-ready? wave)\n\n"

--- a/src/text.h
+++ b/src/text.h
@@ -15,16 +15,6 @@ static const char *jaylib_getcstring(const Janet *argv, int32_t n) {
     return janet_getcstring(argv, n);
 }
 
-static const unsigned char *jaylib_getunsignedcstring(const Janet *argv, int32_t n) {
-    if (janet_checktype(argv[n], JANET_BUFFER)) {
-        JanetBuffer *buf = janet_unwrap_buffer(argv[n]);
-        janet_buffer_push_u8(buf, 0);
-        buf->count--;
-        return (const unsigned char *)buf->data;
-    }
-    return (const unsigned char *)janet_getcstring(argv, n);
-}
-
 static Janet cfun_GetFontDefault(int32_t argc, Janet *argv) {
     (void) argv;
     janet_fixarity(argc, 0);

--- a/src/types.h
+++ b/src/types.h
@@ -700,3 +700,13 @@ static Janet jaylib_wrap_raycollision(RayCollision rayCollision) {
     janet_table_put(table, janet_wrap_keyword("normal"), jaylib_wrap_vec3(rayCollision.normal));
     return janet_wrap_table(table);
 }
+
+static const unsigned char *jaylib_getunsignedcstring(const Janet *argv, int32_t n) {
+    if (janet_checktype(argv[n], JANET_BUFFER)) {
+        JanetBuffer *buf = janet_unwrap_buffer(argv[n]);
+        janet_buffer_push_u8(buf, 0);
+        buf->count--;
+        return (const unsigned char *)buf->data;
+    }
+    return (const unsigned char *)janet_getcstring(argv, n);
+}


### PR DESCRIPTION
Moved `jaylib_getunsignedcstring` from fonts to a general `types.h` since it is used in a similar interface in fonts' `LoadFontFromMemory`.