### PR TITLE
Upgrade to Raylib 5.0

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -249,9 +249,9 @@
 
 // Image generation functions
 [x] Image GenImageColor(int width, int height, Color color)
-[x] Image GenImageGradientV(int width, int height, Color top, Color bottom)
-[x] Image GenImageGradientH(int width, int height, Color left, Color right)
+[x] Image GenImageGradientLinear(int width, int height, int direction, Color start, Color end)
 [x] Image GenImageGradientRadial(int width, int height, float density, Color inner, Color outer)
+[x] Image GenImageGradientSquare(int width, int height, float density, Color inner, Color outer)
 [x] Image GenImageChecked(int width, int height, int checksX, int checksY, Color col1, Color col2)
 [x] Image GenImageWhiteNoise(int width, int height, float factor)
 [x] Image GenImagePerlinNoise(int width, int height, int offsetX, int offsetY, float scale)

--- a/src/image.h
+++ b/src/image.h
@@ -509,25 +509,15 @@ static Janet cfun_GenImageColor(int32_t argc, Janet *argv) {
     return janet_wrap_abstract(image);
 }
 
-static Janet cfun_GenImageGradientV(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 4);
+static Janet cfun_GenImageGradientLinear(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 5);
     int width = janet_getinteger(argv, 0);
     int height = janet_getinteger(argv, 1);
-    Color c1 = jaylib_getcolor(argv, 2);
-    Color c2 = jaylib_getcolor(argv, 3);
+    int direction = janet_getinteger(argv, 2);
+    Color start = jaylib_getcolor(argv, 3);
+    Color end = jaylib_getcolor(argv, 4);
     Image *image = janet_abstract(&AT_Image, sizeof(Image));
-    *image = GenImageGradientV(width, height, c1, c2);
-    return janet_wrap_abstract(image);
-}
-
-static Janet cfun_GenImageGradientH(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 4);
-    int width = janet_getinteger(argv, 0);
-    int height = janet_getinteger(argv, 1);
-    Color c1 = jaylib_getcolor(argv, 2);
-    Color c2 = jaylib_getcolor(argv, 3);
-    Image *image = janet_abstract(&AT_Image, sizeof(Image));
-    *image = GenImageGradientH(width, height, c1, c2);
+    *image = GenImageGradientLinear(width, height, direction, start, end);
     return janet_wrap_abstract(image);
 }
 
@@ -540,6 +530,18 @@ static Janet cfun_GenImageGradientRadial(int32_t argc, Janet *argv) {
     Color outer = jaylib_getcolor(argv, 4);
     Image *image = janet_abstract(&AT_Image, sizeof(Image));
     *image = GenImageGradientRadial(width, height, density, inner, outer);
+    return janet_wrap_abstract(image);
+}
+
+static Janet cfun_GenImageGradientSquare(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 5);
+    int width = janet_getinteger(argv, 0);
+    int height = janet_getinteger(argv, 1);
+    float density = (float) janet_getnumber(argv, 2);
+    Color inner = jaylib_getcolor(argv, 3);
+    Color outer = jaylib_getcolor(argv, 4);
+    Image *image = janet_abstract(&AT_Image, sizeof(Image));
+    *image = GenImageGradientSquare(width, height, density, inner, outer);
     return janet_wrap_abstract(image);
 }
 
@@ -876,17 +878,17 @@ static const JanetReg image_cfuns[] = {
         "(gen-image-color width height color)\n\n"
         "Generate image: plain color"
     },
-    {"gen-image-gradient-v", cfun_GenImageGradientV, 
-        "(gen-image-gradient-v width height top bottom)\n\n"
-        "Generate image: vertical gradient"
-    },
-    {"gen-image-gradient-h", cfun_GenImageGradientH, 
-        "(gen-image-gradient-h width height left right)\n\n"
-        "Generate image: horizontal gradient"
+    {"gen-image-gradient-linear", cfun_GenImageGradientLinear, 
+        "(gen-image-gradient-linear width height direction start end)\n\n"
+        "Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient"
     },
     {"gen-image-gradient-radial", cfun_GenImageGradientRadial, 
         "(gen-image-gradient-radial width height density inner outer)\n\n"
         "Generate image: radial gradient"
+    },
+    {"gen-image-gradient-square", cfun_GenImageGradientSquare, 
+        "(gen-image-gradient-square width height density inner outer)\n\n"
+        "Generate image: square gradient"
     },
     {"gen-image-checked", cfun_GenImageChecked, 
         "(gen-image-checked width height checks-x checks-y color1 color2)\n\n"


### PR DESCRIPTION
https://github.com/raysan5/raylib/releases/tag/5.0

`GenImageGradientV` and `GenImageGradientH` were replaced with `GenImageGradientLinear`. I also added `GenImageGradientSquare` for completeness.