### PR TITLE
Address #56: two-argument load-font-ex

### DIFF
--- a/src/text.h
+++ b/src/text.h
@@ -204,7 +204,7 @@ static JanetReg text_cfuns[] = {
         "Check if a font is ready"
     },
     {"load-font-ex", cfun_LoadFontEx,
-        "(load-font-ex file-name font-size font-chars)\n\n"
+        "(load-font-ex file-name font-size &opt font-chars)\n\n"
         "Load font from file with extended parameters"
     },
     {"load-font-from-memory", cfun_LoadFontFromMemory,

--- a/src/text.h
+++ b/src/text.h
@@ -42,17 +42,21 @@ static Janet cfun_IsFontReady(int32_t argc, Janet *argv) {
 }
 
 static Janet cfun_LoadFontEx(int32_t argc, Janet *argv) {
-    janet_fixarity(argc, 3);
+    janet_arity(argc, 2, 3);
     const char *fileName = janet_getcstring(argv, 0);
     int fontSize = janet_getinteger(argv, 1);
-    JanetView ints = janet_getindexed(argv, 2);
-    int *raw_ints = janet_smalloc(sizeof(int) * ints.len);
-    for (int32_t i = 0; i < ints.len; i++) {
-        raw_ints[i] = janet_getinteger(ints.items, i);
-    }
     Font *font = janet_abstract(&AT_Font, sizeof(Font));
-    *font = LoadFontEx(fileName, fontSize, raw_ints, ints.len);
-    janet_sfree(raw_ints);
+    if (argc == 2) {
+        *font = LoadFontEx(fileName, fontSize, NULL, 0);
+    } else {
+        JanetView ints = janet_getindexed(argv, 2);
+        int *raw_ints = janet_smalloc(sizeof(int) * ints.len);
+        for (int32_t i = 0; i < ints.len; i++) {
+            raw_ints[i] = janet_getinteger(ints.items, i);
+        }
+        *font = LoadFontEx(fileName, fontSize, raw_ints, ints.len);
+        janet_sfree(raw_ints);
+    }
     return janet_wrap_abstract(font);
 }
 


### PR DESCRIPTION
This PR is an attempt to address #56.

The approach taken is for `load-font-ex` to also handle being called with 2 arguments (in addition to its existing ability to handle 3 arguments).

If called with 2 arguments, the 3rd and 4th arguments to `LoadFontEx` are set to `NULL` and `0` respectively.

---

I've made a demo in a fork.

If interested in trying, instructions are [here](https://github.com/sogaiu/jaylib/blob/load-font-ex-convenience-demo/demo.README) and the demo code file is [here](https://github.com/sogaiu/jaylib/blob/load-font-ex-convenience-demo/load-font-ex-demo.janet).