### PR TITLE
Camera3D: Fix naming inconsistency with documentation and arguments

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -820,9 +820,9 @@ static Janet cfun_Camera3D(int32_t argc, Janet *argv) {
             camera->position = jaylib_getvec3(argv, i + 1);
         } else if (!janet_cstrcmp(kw, "up")) {
             camera->up = jaylib_getvec3(argv, i + 1);
-        } else if (!janet_cstrcmp(kw, "fovy")) {
+        } else if ((!janet_cstrcmp(kw, "fov-y")) || (!janet_cstrcmp(kw, "fovy"))) {
             camera->fovy = (float) janet_getnumber(argv, i + 1);
-        } else if (!janet_cstrcmp(kw, "type")) {
+        } else if ((!janet_cstrcmp(kw, "projection")) || (!janet_cstrcmp(kw, "type"))) {
             const uint8_t *cameraType = janet_getkeyword(argv, i + 1);
             if (!janet_cstrcmp(cameraType, "perspective")) {
                 camera->projection = CAMERA_PERSPECTIVE;
@@ -1295,13 +1295,13 @@ static JanetReg core_cfuns[] = {
         " - :zoom     = Camera zoom (scaling), should be 1.0f by default \n"
     },
     {"camera-3d", cfun_Camera3D, 
-        "(camera-3d :position [x y z] :target [x y z] :up [x y z] :fovy float :type keyword)\n\n" 
+        "(camera-3d :position [x y z] :target [x y z] :up [x y z] :fov-y float :projection keyword)\n\n" 
         "Instantiate a Camera3D. \n"
         " - :position   = Camera position \n"
         " - :target     = Camera target it looks-at \n"
         " - :up         = Camera up vector (rotation over its axis) \n"
-        " - :fovy       = Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic \n"
-        " - :type       = Camera projection: :perspective or :orthographic \n"
+        " - :fov-y      = Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic \n"
+        " - :projection = Camera projection: :perspective or :orthographic \n"
     },
     {"update-camera", cfun_UpdateCamera, 
         "(update-camera camera mode)\n\n" 

--- a/src/core.h
+++ b/src/core.h
@@ -820,9 +820,9 @@ static Janet cfun_Camera3D(int32_t argc, Janet *argv) {
             camera->position = jaylib_getvec3(argv, i + 1);
         } else if (!janet_cstrcmp(kw, "up")) {
             camera->up = jaylib_getvec3(argv, i + 1);
-        } else if (!janet_cstrcmp(kw, "fovy")) {
+        } else if (!janet_cstrcmp(kw, "fov-y")) {
             camera->fovy = (float) janet_getnumber(argv, i + 1);
-        } else if (!janet_cstrcmp(kw, "type")) {
+        } else if (!janet_cstrcmp(kw, "projection")) {
             const uint8_t *cameraType = janet_getkeyword(argv, i + 1);
             if (!janet_cstrcmp(cameraType, "perspective")) {
                 camera->projection = CAMERA_PERSPECTIVE;
@@ -1301,7 +1301,7 @@ static JanetReg core_cfuns[] = {
         " - :target     = Camera target it looks-at \n"
         " - :up         = Camera up vector (rotation over its axis) \n"
         " - :fov-y      = Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic \n"
-        " - :projection = Camera projection: CAMERA\\_PERSPECTIVE or CAMERA\\_ORTHOGRAPHIC \n"
+        " - :projection = Camera projection: :perspective or :orthographic \n"
     },
     {"update-camera", cfun_UpdateCamera, 
         "(update-camera camera mode)\n\n" 

--- a/src/core.h
+++ b/src/core.h
@@ -820,9 +820,9 @@ static Janet cfun_Camera3D(int32_t argc, Janet *argv) {
             camera->position = jaylib_getvec3(argv, i + 1);
         } else if (!janet_cstrcmp(kw, "up")) {
             camera->up = jaylib_getvec3(argv, i + 1);
-        } else if (!janet_cstrcmp(kw, "fov-y")) {
+        } else if (!janet_cstrcmp(kw, "fovy")) {
             camera->fovy = (float) janet_getnumber(argv, i + 1);
-        } else if (!janet_cstrcmp(kw, "projection")) {
+        } else if (!janet_cstrcmp(kw, "type")) {
             const uint8_t *cameraType = janet_getkeyword(argv, i + 1);
             if (!janet_cstrcmp(cameraType, "perspective")) {
                 camera->projection = CAMERA_PERSPECTIVE;
@@ -1295,13 +1295,13 @@ static JanetReg core_cfuns[] = {
         " - :zoom     = Camera zoom (scaling), should be 1.0f by default \n"
     },
     {"camera-3d", cfun_Camera3D, 
-        "(camera-3d :position [x y z] :target [x y z] :up [x y z] :fov-y float :projection int)\n\n" 
+        "(camera-3d :position [x y z] :target [x y z] :up [x y z] :fovy float :type keyword)\n\n" 
         "Instantiate a Camera3D. \n"
         " - :position   = Camera position \n"
         " - :target     = Camera target it looks-at \n"
         " - :up         = Camera up vector (rotation over its axis) \n"
-        " - :fov-y      = Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic \n"
-        " - :projection = Camera projection: :perspective or :orthographic \n"
+        " - :fovy       = Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic \n"
+        " - :type       = Camera projection: :perspective or :orthographic \n"
     },
     {"update-camera", cfun_UpdateCamera, 
         "(update-camera camera mode)\n\n" 


### PR DESCRIPTION
The choice was to either change the documentation for the `Camera3D` constructor or change the arguments. I prefer this as it makes it consistent and clear to the user